### PR TITLE
Big bundle of improvements from some offline refactoring.

### DIFF
--- a/transactionoutbox-core/src/main/java/com/gruelbox/transactionoutbox/AbstractThreadLocalTransactionManager.java
+++ b/transactionoutbox-core/src/main/java/com/gruelbox/transactionoutbox/AbstractThreadLocalTransactionManager.java
@@ -50,9 +50,9 @@ abstract class AbstractThreadLocalTransactionManager<TX extends ThreadLocalTrans
   }
 
   @Override
-  public final <E extends Exception> void requireTransaction(ThrowingTransactionalWork<E> work)
-      throws E {
-    work.doWork(peekTransaction().orElseThrow(NoTransactionActiveException::new));
+  public <T, E extends Exception> T requireTransactionReturns(
+      ThrowingTransactionalSupplier<T, E> work) throws E, NoTransactionActiveException {
+    return work.doWork(peekTransaction().orElseThrow(NoTransactionActiveException::new));
   }
 
   final TX pushTransaction(TX transaction) {

--- a/transactionoutbox-core/src/main/java/com/gruelbox/transactionoutbox/ExecutorSubmitter.java
+++ b/transactionoutbox-core/src/main/java/com/gruelbox/transactionoutbox/ExecutorSubmitter.java
@@ -1,0 +1,30 @@
+package com.gruelbox.transactionoutbox;
+
+import java.util.concurrent.Executor;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.function.Consumer;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@AllArgsConstructor(access = AccessLevel.PACKAGE)
+class ExecutorSubmitter implements Submitter {
+
+  private final Executor executor;
+
+  @Override
+  public void submit(TransactionOutboxEntry entry, Consumer<TransactionOutboxEntry> localExecutor) {
+    try {
+      executor.execute(() -> localExecutor.accept(entry));
+      log.debug("Submitted {} for immediate processing", entry.description());
+    } catch (RejectedExecutionException e) {
+      log.debug("Queued {} for processing when executor is available", entry.description());
+    } catch (Exception e) {
+      log.warn(
+          "Failed to submit {} for execution. It will be re-attempted later.",
+          entry.description(),
+          e);
+    }
+  }
+}

--- a/transactionoutbox-core/src/main/java/com/gruelbox/transactionoutbox/InvocationSerializer.java
+++ b/transactionoutbox-core/src/main/java/com/gruelbox/transactionoutbox/InvocationSerializer.java
@@ -1,10 +1,69 @@
 package com.gruelbox.transactionoutbox;
 
 import java.io.Reader;
+import java.io.Writer;
 
+/**
+ * {@link Invocation} objects are inherently difficult to serialize safely since they are
+ * unpredictably polymorphic. Allowing them to contain <em>any</em> type reference opens you
+ * up to a host of code injection attacks. At the same time, allowing possibly-unstable types into
+ * serialized {@link Invocation}s can result in compatibility issues, with still unprocessed entries
+ * in the database containing older versions of your classes. To avoid this, it makes sense to
+ * whitelist the types supported and restrict this whitelist to known-stable types such as
+ * primitives and common JDK value types. {@link #createDefaultJsonSerializer()} provides exactly
+ * this and is used by default. However, if you want to extend this list or use a different
+ * serialization format, you can create your own implementation here, at your own risk.
+ */
 public interface InvocationSerializer {
 
-  String serialize(Invocation invocation);
+  /**
+   * Creates a locked-down serializer which supports a limited list of primitives and simple
+   * JDK value types. Only the following are supported currently:
+   *
+   * <ul>
+   *   <li>{@link Invocation} itself</i>
+   *   <li>Primitive types such as {@code int} or {@code double} or the boxed equivalents
+   *   <li>{@link String}
+   *   <li>{@link java.util.Date}
+   *   <li>The {@code java.time} classes:
+   *       <ul>
+   *         <li>{@link java.time.DayOfWeek}
+   *         <li>{@link java.time.Duration}
+   *         <li>{@link java.time.Instant}
+   *         <li>{@link java.time.LocalDate}
+   *         <li>{@link java.time.LocalDateTime}
+   *         <li>{@link java.time.Month}
+   *         <li>{@link java.time.MonthDay}
+   *         <li>{@link java.time.Period}
+   *         <li>{@link java.time.Year}
+   *         <li>{@link java.time.YearMonth}
+   *         <li>{@link java.time.ZoneOffset}
+   *         <li>{@link java.time.DayOfWeek}
+   *         <li>{@link java.time.temporal.ChronoUnit}
+   *       </ul>
+   *   <li>Arrays specifically typed to one of the above types.
+   * </ul>
+   *
+   * @return The serializer.
+   */
+  static InvocationSerializer createDefaultJsonSerializer() {
+    return new DefaultInvocationSerializer();
+  }
 
-  Invocation deserialize(Reader reader);
+  /**
+   * Serializes an invocation to the supplied writer.
+   *
+   * @param invocation The invocation.
+   * @param writer The writer.
+   */
+  void serializeInvocation(Invocation invocation, Writer writer);
+
+  /**
+   * Deserializes an invocation from the supplied reader.
+   *
+   * @param reader The reader.
+   * @return The deserialized invocation.
+   */
+  Invocation deserializeInvocation(Reader reader);
+
 }

--- a/transactionoutbox-core/src/main/java/com/gruelbox/transactionoutbox/InvocationSerializer.java
+++ b/transactionoutbox-core/src/main/java/com/gruelbox/transactionoutbox/InvocationSerializer.java
@@ -21,7 +21,7 @@ public interface InvocationSerializer {
    * JDK value types. Only the following are supported currently:
    *
    * <ul>
-   *   <li>{@link Invocation} itself</i>
+   *   <li>{@link Invocation} itself</li>
    *   <li>Primitive types such as {@code int} or {@code double} or the boxed equivalents
    *   <li>{@link String}
    *   <li>{@link java.util.Date}

--- a/transactionoutbox-core/src/main/java/com/gruelbox/transactionoutbox/Persistor.java
+++ b/transactionoutbox-core/src/main/java/com/gruelbox/transactionoutbox/Persistor.java
@@ -9,55 +9,15 @@ import java.util.List;
 public interface Persistor {
 
   /**
-   * Uses the default relational persistor.
+   * Uses the default relational persistor. Shortcut for:
+   *
+   * <code>DefaultPersistor.builder().dialect(dialect).build();</code>
    *
    * @param dialect The database dialect.
    * @return The persistor.
    */
   static DefaultPersistor forDialect(Dialect dialect) {
     return DefaultPersistor.builder().dialect(dialect).build();
-  }
-
-  /**
-   * Uses the default relational persistor with an alternative serializer.
-   *
-   * <p>An {@link Invocation} is normally serialised to the database as JSON, since methods could
-   * take any number of arguments of a variety of parameter types. The default serializer has a
-   * number of limitations. Only the following are supported currently:
-   *
-   * <ul>
-   *   <li>Primitive types such as {@code int} or {@code double} or the boxed equivalents.
-   *   <li>{@link String}
-   *   <li>{@link java.util.Date}
-   *   <li>The {@code java.time} classes:
-   *       <ul>
-   *         <li>{@link java.time.DayOfWeek}
-   *         <li>{@link java.time.Duration}
-   *         <li>{@link java.time.Instant}
-   *         <li>{@link java.time.LocalDate}
-   *         <li>{@link java.time.LocalDateTime}
-   *         <li>{@link java.time.Month}
-   *         <li>{@link java.time.MonthDay}
-   *         <li>{@link java.time.Period}
-   *         <li>{@link java.time.Year}
-   *         <li>{@link java.time.YearMonth}
-   *         <li>{@link java.time.ZoneOffset}
-   *         <li>{@link java.time.DayOfWeek}
-   *         <li>{@link java.time.temporal.ChronoUnit}
-   *       </ul>
-   *   <li>Arrays specifically typed to one of the above types.
-   * </ul>
-   *
-   * <p>If any of these limitations restrict your application, or if you don't need anything with
-   * such general support and want a more specific, faster implementation, you can provide your own
-   * {@link InvocationSerializer} here.
-   *
-   * @param dialect The database dialect.
-   * @param serializer The serializer.
-   * @return The persistor.
-   */
-  static DefaultPersistor forDialect(Dialect dialect, InvocationSerializer serializer) {
-    return DefaultPersistor.builder().dialect(dialect).serializer(serializer).build();
   }
 
   /**
@@ -94,6 +54,8 @@ public interface Persistor {
   void update(Transaction tx, TransactionOutboxEntry entry) throws Exception;
 
   boolean lock(Transaction tx, TransactionOutboxEntry entry) throws Exception;
+
+  boolean whitelist(Transaction tx, String entryId) throws Exception;
 
   List<TransactionOutboxEntry> selectBatch(Transaction tx, int batchSize) throws Exception;
 }

--- a/transactionoutbox-core/src/main/java/com/gruelbox/transactionoutbox/Submitter.java
+++ b/transactionoutbox-core/src/main/java/com/gruelbox/transactionoutbox/Submitter.java
@@ -1,0 +1,100 @@
+package com.gruelbox.transactionoutbox;
+
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ForkJoinPool;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+
+/**
+ * Called by {@link TransactionOutbox} to submit work for background processing.
+ */
+public interface Submitter {
+
+  /**
+   * Schedules background work using a local {@link Executor} implementation. Note that the {@link
+   * Runnable}s submitted to this will not be {@link java.io.Serializable} so will not be suitable
+   * for remoting. Remote submission of work is not yet supported.
+   *
+   * <p>Note that there are some important aspects that should be considered in the configuration
+   * of this executor:
+   *
+   * <ul>
+   *   <li>Should use a BOUNDED blocking queue implementation such as {@link ArrayBlockingQueue},
+   *       otherwise under high volume, the queue may get so large it causes out-of-memory errors.
+   *   <li>Should use a {@link java.util.concurrent.RejectedExecutionHandler} which either throws
+   *       (such as {@link java.util.concurrent.ThreadPoolExecutor.AbortPolicy}), silently fails
+   *       (such as {@link java.util.concurrent.ThreadPoolExecutor.DiscardPolicy}) or blocks the
+   *       calling thread until a thread is available. It should <strong>not</strong> execute the
+   *       work in the calling thread (e.g. {@link
+   *       java.util.concurrent.ThreadPoolExecutor.CallerRunsPolicy}, since this could result in
+   *       unpredictable effects with tasks assuming they will be run in a different thread context
+   *       corrupting thread state. Generally, throwing or silently failing are preferred since this
+   *       allows the database to absorb all backpressure, but if you have a strong reason to choose
+   *       a blocking policy to enforce upstream backpressure, be aware that
+   *       {@link TransactionOutbox#flush()} can potentially block for a long period of time too,
+   *       so design any background processing which calls it accordingly (e.g. avoid calling from a
+   *       timed scheduled job; perhaps instead simply loop it).
+   *   <li>The queue can afford to be quite large in most realistic production deployments, and it
+   *       is advised that it be so (10000+).
+   * </ul>
+   *
+   * @return The submitter.
+   */
+  static Submitter withExecutor(Executor executor) {
+    return new ExecutorSubmitter(executor);
+  }
+
+  /**
+   * Schedules background worh with a {@link ThreadPoolExecutor}, sized to match {@link
+   * ForkJoinPool#commonPool()} (or one thread, whichever is the larger), with a maximum queue size
+   * of 16384 before work is discarded.
+   *
+   * @return The submitter.
+   */
+  static Submitter withDefaultExecutor() {
+    return withExecutor(new ThreadPoolExecutor(
+        1,
+        Math.min(1, ForkJoinPool.commonPool().getParallelism()),
+        0L,
+        TimeUnit.MILLISECONDS,
+        new ArrayBlockingQueue<Runnable>(16384)));
+  }
+
+  /**
+   * Submits a transaction outbox task for processing. The {@link TransactionOutboxEntry} is
+   * provided, along with a {@code localExecutor} which can run the work immediately. An
+   * implementation may validly do any of the following:
+   *
+   * <ul>
+   *   <li>Submit a call to {@code localExecutor} in a local thread, e.g. using an
+   *   {@link Executor}. This is what implementations returned by
+   *   {@link #withExecutor(Executor)} or {@link #withDefaultExecutor()} will do, and is
+   *   recommended in almost all cases.</li>
+   *   <li>Serialize the {@link TransactionOutboxEntry}, send it to another instance (e.g. via
+   *   a queue) and have the handler code call
+   *   {@link TransactionOutbox#processNow(TransactionOutboxEntry)}. Such an approach should
+   *   not generally be necessary since {@link TransactionOutbox#flush()} is designed to be
+   *   called repeatedly on multiple instances. This means there is a degree of load balancing
+   *   built into the system, but when dealing with very high load, very low run-time tasks,
+   *   this can get overwhelmed and direct multi-instance queuing can help balance the load
+   *   at source. <strong>Note:</strong> it is recommended that the {@code invocation} property
+   *   of the {@link TransactionOutboxEntry} be serialized using
+   *   {@link InvocationSerializer#}</li>
+   *   <li>Pass the {@code entry} directly to the {@code localExecutor}. This will run the
+   *   work immediately in the calling thread and is therefore generally not recommended;
+   *   the calling thread will be either the thread calling
+   *   {@link TransactionOutbox#schedule(Class)} (effectively making the work synchronous)
+   *   or the background poll thread (limiting work in progress to one). It can, however,
+   *   be useful for test cases.</li>
+   * </ul>
+   *
+   * @param entry The entry to process.
+   * @param localExecutor Provides a means of running the work directly locally (it is
+   *                      effectively just a call to
+   *                      {@link TransactionOutbox#processNow(TransactionOutboxEntry)}).
+   */
+  void submit(TransactionOutboxEntry entry, Consumer<TransactionOutboxEntry> localExecutor);
+
+}

--- a/transactionoutbox-core/src/main/java/com/gruelbox/transactionoutbox/Submitter.java
+++ b/transactionoutbox-core/src/main/java/com/gruelbox/transactionoutbox/Submitter.java
@@ -40,6 +40,7 @@ public interface Submitter {
    *       is advised that it be so (10000+).
    * </ul>
    *
+   * @param executor The executor.
    * @return The submitter.
    */
   static Submitter withExecutor(Executor executor) {
@@ -81,7 +82,7 @@ public interface Submitter {
    *   this can get overwhelmed and direct multi-instance queuing can help balance the load
    *   at source. <strong>Note:</strong> it is recommended that the {@code invocation} property
    *   of the {@link TransactionOutboxEntry} be serialized using
-   *   {@link InvocationSerializer#}</li>
+   *   {@link InvocationSerializer#createDefaultJsonSerializer()}</li>
    *   <li>Pass the {@code entry} directly to the {@code localExecutor}. This will run the
    *   work immediately in the calling thread and is therefore generally not recommended;
    *   the calling thread will be either the thread calling

--- a/transactionoutbox-core/src/main/java/com/gruelbox/transactionoutbox/TransactionManager.java
+++ b/transactionoutbox-core/src/main/java/com/gruelbox/transactionoutbox/TransactionManager.java
@@ -130,6 +130,20 @@ public interface TransactionManager {
    * @throws E If any exception is thrown by {@link Runnable}.
    * @throws NoTransactionActiveException If a transaction is not currently active.
    */
-  <E extends Exception> void requireTransaction(ThrowingTransactionalWork<E> work)
+  default <E extends Exception> void requireTransaction(ThrowingTransactionalWork<E> work)
+      throws E, NoTransactionActiveException {
+    requireTransactionReturns(ThrowingTransactionalSupplier.fromWork(work));
+  }
+
+  /**
+   * Runs the specified work in the context of the "current" transaction (the definition of which is
+   * up to the implementation).
+   *
+   * @param work Code which must be called while the transaction is active.
+   * @param <E> The exception type.
+   * @throws E If any exception is thrown by {@link Runnable}.
+   * @throws NoTransactionActiveException If a transaction is not currently active.
+   */
+  <T, E extends Exception> T requireTransactionReturns(ThrowingTransactionalSupplier<T, E> work)
       throws E, NoTransactionActiveException;
 }

--- a/transactionoutbox-core/src/main/java/com/gruelbox/transactionoutbox/TransactionManager.java
+++ b/transactionoutbox-core/src/main/java/com/gruelbox/transactionoutbox/TransactionManager.java
@@ -140,6 +140,7 @@ public interface TransactionManager {
    * up to the implementation).
    *
    * @param work Code which must be called while the transaction is active.
+   * @param <T> The type returned.
    * @param <E> The exception type.
    * @throws E If any exception is thrown by {@link Runnable}.
    * @throws NoTransactionActiveException If a transaction is not currently active.

--- a/transactionoutbox-core/src/main/java/com/gruelbox/transactionoutbox/TransactionOutbox.java
+++ b/transactionoutbox-core/src/main/java/com/gruelbox/transactionoutbox/TransactionOutbox.java
@@ -197,10 +197,12 @@ public class TransactionOutbox {
   }
 
   /**
-   * Marks a blacklisted entry back to not blacklisted and resets the attempt count.
-   * Requires an active transaction.
+   * Marks a blacklisted entry back to not blacklisted and resets the attempt count. Requires an
+   * active transaction.
    *
    * @param entryId The entry id.
+   * @return True if the whitelisting request was successful. May return false if another thread
+   * whitelisted the entry first.
    */
   public boolean whitelist(String entryId) {
     log.info("Whitelisting entry {}", entryId);

--- a/transactionoutbox-core/src/main/java/com/gruelbox/transactionoutbox/TransactionOutbox.java
+++ b/transactionoutbox-core/src/main/java/com/gruelbox/transactionoutbox/TransactionOutbox.java
@@ -13,13 +13,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
-import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.Executor;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.ForkJoinPool;
-import java.util.concurrent.RejectedExecutionException;
-import java.util.concurrent.ThreadPoolExecutor;
-import java.util.concurrent.TimeUnit;
 import javax.validation.ClockProvider;
 import javax.validation.Valid;
 import javax.validation.constraints.Min;
@@ -29,13 +23,14 @@ import lombok.extern.slf4j.Slf4j;
 import org.hibernate.validator.internal.engine.DefaultClockProvider;
 
 /**
- * An implementation of the <a
- * href="https://microservices.io/patterns/data/transactional-outbox.html">Transactional Outbox</a>
- * pattern for Java. See <a href="https://github.com/gruelbox/transaction-outbox">README</a> for
- * usage instructions.
+ * An implementation of the <a href="https://microservices.io/patterns/data/transactional-outbox.html">Transactional
+ * Outbox</a> pattern for Java. See <a href="https://github.com/gruelbox/transaction-outbox">README</a>
+ * for usage instructions.
  */
 @Slf4j
 public class TransactionOutbox {
+
+  private static final int DEFAULT_FLUSH_BATCH_SIZE = 4096;
 
   @NotNull private final TransactionManager transactionManager;
 
@@ -48,7 +43,9 @@ public class TransactionOutbox {
    * cases. If re-implementing this interface, read the documentation on {@link Persistor}
    * carefully.
    */
-  @Valid @NotNull private final Persistor persistor;
+  @Valid
+  @NotNull
+  private final Persistor persistor;
 
   /**
    * Responsible for describing a class as a name and creating instances of that class at runtime
@@ -56,39 +53,20 @@ public class TransactionOutbox {
    *
    * <p>Defaults to {@link Instantiator#usingReflection()}.
    */
-  @Valid @NotNull private final Instantiator instantiator;
+  @Valid
+  @NotNull
+  private final Instantiator instantiator;
 
   /**
-   * The executor used for scheduling background work.
+   * Used for scheduling background work.
    *
-   * <p>Note that there are some important aspects that should be considered in the configuration of
-   * this executor:
+   * <p>If no submitter is specified, {@link TransactionOutbox} will use {@link
+   * Submitter#withDefaultExecutor()}.</p>
    *
-   * <ul>
-   *   <li>Should use a BOUNDED blocking queue implementation such as {@link ArrayBlockingQueue},
-   *       otherwise under high volume, the queue may get so large it causes out-of-memory errors.
-   *   <li>Should use a {@link java.util.concurrent.RejectedExecutionHandler} which either throws
-   *       (such as {@link java.util.concurrent.ThreadPoolExecutor.AbortPolicy}), silently fails
-   *       (such as {@link java.util.concurrent.ThreadPoolExecutor.DiscardPolicy}) or blocks the
-   *       calling thread until a thread is available. It should <strong>not</strong> execute the
-   *       work in the calling thread (e.g. {@link
-   *       java.util.concurrent.ThreadPoolExecutor.CallerRunsPolicy}, since this could result in
-   *       unpredictable effects with tasks assuming they will be run in a different thread context
-   *       corrupting thread state. Generally, throwing or silently failing are preferred since this
-   *       allows the database to absorb all backpressure, but if you have a strong reason to choose
-   *       a blocking policy to enforce upstream backpressure, be aware that {@link #flush()} can
-   *       potentially block for a long period of time too, so design any background processing
-   *       which calls it accordingly (e.g. avoid calling from a timed scheduled job; perhaps
-   *       instead simply loop it).
-   *   <li>The queue can afford to be quite large in most realistic production deployments, and it
-   *       is advised that it be so (10000+).
-   * </ul>
-   *
-   * <p>If no executor service is specified, {@link TransactionOutbox} will use its own local {@link
-   * ExecutorService}, sized to match {@link ForkJoinPool#commonPool()} (or one thread, whichever is
-   * the larger), with a maximum queue size of 16384 before work is discarded.
+   * <p>See {@link Submitter#withExecutor(Executor)} for more information on designing bespoke
+   * submitters for remoting.</p>
    */
-  @NotNull private final Executor executor;
+  @NotNull private final Submitter submitter;
 
   /**
    * How often tasks should be re-attempted. This should be balanced with {@link #flushBatchSize}
@@ -98,7 +76,9 @@ public class TransactionOutbox {
    */
   @NotNull private final Duration attemptFrequency;
 
-  /** After now many attempts a task should be blacklisted. Defaults to 5. */
+  /**
+   * After now many attempts a task should be blacklisted. Defaults to 5.
+   */
   @Min(1)
   private final int blacklistAfterAttempts;
 
@@ -118,14 +98,16 @@ public class TransactionOutbox {
    */
   @NotNull private final ClockProvider clockProvider;
 
-  /** Event listener for use in testing. */
+  /**
+   * Event listener for use in testing.
+   */
   @NotNull private final TransactionOutboxListener listener;
 
   @Builder
   private TransactionOutbox(
       TransactionManager transactionManager,
       Instantiator instantiator,
-      Executor executor,
+      Submitter submitter,
       Duration attemptFrequency,
       int blacklistAfterAttempts,
       int flushBatchSize,
@@ -135,21 +117,13 @@ public class TransactionOutbox {
     this.transactionManager = transactionManager;
     this.instantiator = Utils.firstNonNull(instantiator, Instantiator::usingReflection);
     this.persistor = persistor;
-    this.executor =
-        Utils.firstNonNull(
-            executor,
-            () ->
-                new ThreadPoolExecutor(
-                    1,
-                    Math.min(1, ForkJoinPool.commonPool().getParallelism()),
-                    0L,
-                    TimeUnit.MILLISECONDS,
-                    new ArrayBlockingQueue<Runnable>(16384)));
+    this.submitter = Utils.firstNonNull(submitter, Submitter::withDefaultExecutor);
     this.attemptFrequency = Utils.firstNonNull(attemptFrequency, () -> Duration.of(2, MINUTES));
     this.blacklistAfterAttempts = blacklistAfterAttempts <= 1 ? 5 : blacklistAfterAttempts;
-    this.flushBatchSize = flushBatchSize <= 1 ? 4096 : flushBatchSize;
+    this.flushBatchSize = flushBatchSize <= 1 ? DEFAULT_FLUSH_BATCH_SIZE : flushBatchSize;
     this.clockProvider = Utils.firstNonNull(clockProvider, () -> DefaultClockProvider.INSTANCE);
-    this.listener = Utils.firstNonNull(listener, () -> entry -> {});
+    this.listener = Utils.firstNonNull(listener, () -> new TransactionOutboxListener() {
+    });
     Utils.validate(this);
     this.persistor.migrate(transactionManager);
   }
@@ -169,12 +143,12 @@ public class TransactionOutbox {
    * <p>This will write a record to the database using the supplied {@link Persistor} and {@link
    * Instantiator}, using the current database transaction, which will get rolled back if the rest
    * of the transaction is, and thus never processed. However, if the transaction is committed, the
-   * real method will be called immediately afterwards using the supplied {@link #executor}. Should
+   * real method will be called immediately afterwards using the supplied {@link #submitter}. Should
    * that fail, the call will be reattempted whenever {@link #flush()} is called, provided at least
    * {@link #attemptFrequency} has passed since the time the task was last attempted.
    *
    * @param clazz The class to proxy.
-   * @param <T> The type to proxy.
+   * @param <T>   The type to proxy.
    * @return The proxy of {@code T}.
    */
   public <T> T schedule(Class<T> clazz) {
@@ -186,10 +160,10 @@ public class TransactionOutbox {
    * than {@link #attemptFrequency} ago and have been tried less than {@link
    * #blacklistAfterAttempts} times) and attempts to resubmit them.
    *
-   * <p>As long as {@link #executor} is non-blocking (i.e. uses a bounded queue with a {@link
+   * <p>As long as {@link #submitter} is non-blocking (e.g. uses a bounded queue with a {@link
    * java.util.concurrent.RejectedExecutionHandler} which throws such as {@link
    * java.util.concurrent.ThreadPoolExecutor.AbortPolicy}), this method will return quickly.
-   * However, if {@link #executor} uses a bounded queue with a blocking policy, this method could
+   * However, if {@link #submitter} uses a bounded queue with a blocking policy, this method could
    * block for a long time, depending on how long the scheduled work takes and how large {@link
    * #flushBatchSize} is.
    *
@@ -222,6 +196,23 @@ public class TransactionOutbox {
     return !batch.isEmpty();
   }
 
+  /**
+   * Marks a blacklisted entry back to not blacklisted and resets the attempt count.
+   * Requires an active transaction.
+   *
+   * @param entryId The entry id.
+   */
+  public boolean whitelist(String entryId) {
+    log.info("Whitelisting entry {}", entryId);
+    try {
+      return transactionManager.requireTransactionReturns(tx ->
+        persistor.whitelist(tx, entryId)
+      );
+    } catch (Exception e) {
+      throw (RuntimeException) Utils.uncheckAndThrow(e);
+    }
+  }
+
   private <T> T schedule(Method method, Object[] args) throws Exception {
     TransactionOutboxEntry entry = newEntry(method, args);
     transactionManager.requireTransaction(
@@ -234,51 +225,37 @@ public class TransactionOutbox {
   }
 
   private void submitNow(TransactionOutboxEntry entry) {
+    submitter.submit(entry, this::processNow);
+  }
+
+  /**
+   * Processes an entry immediately in the current thread. Intended for use in custom
+   * implementations of {@link Submitter} and should not generally otherwise be called.
+   * @param entry The entry.
+   */
+  public void processNow(TransactionOutboxEntry entry) {
     try {
-      executor.execute(
-          () -> {
-            try {
-              var success =
-                  transactionManager.inTransactionReturnsThrows(
-                      transaction -> {
-                        if (!persistor.lock(transaction, entry)) {
-                          return false;
-                        }
-                        log.info("Processing {}", entry.description());
-                        invoke(entry);
-                        persistor.delete(transaction, entry);
-                        return true;
-                      });
-              if (success) {
-                log.info("Processed {}", entry.description());
-                listener.success(entry);
-              } else {
-                log.debug("Skipped task {} - may be locked or already processed", entry.getId());
-              }
-            } catch (InvocationTargetException e) {
-              log.warn(
-                  "Temporarily failed to process {}: {}",
-                  entry.description(),
-                  entry.description(),
-                  e.getCause());
-              updateAttemptCount(entry);
-            } catch (Exception e) {
-              log.warn(
-                  "Temporarily failed to process {}: {}",
-                  entry.description(),
-                  entry.description(),
-                  e);
-              updateAttemptCount(entry);
-            }
-          });
-      log.debug("Submitted {} for immediate processing", entry.description());
-    } catch (RejectedExecutionException e) {
-      log.debug("Queued {} for processing when executor is available", entry.description());
+      var success =
+          transactionManager.inTransactionReturnsThrows(
+              transaction -> {
+                if (!persistor.lock(transaction, entry)) {
+                  return false;
+                }
+                log.info("Processing {}", entry.description());
+                invoke(entry);
+                persistor.delete(transaction, entry);
+                return true;
+              });
+      if (success) {
+        log.info("Processed {}", entry.description());
+        listener.success(entry);
+      } else {
+        log.debug("Skipped task {} - may be locked or already processed", entry.getId());
+      }
+    } catch (InvocationTargetException e) {
+      updateAttemptCount(entry, e.getCause());
     } catch (Exception e) {
-      log.warn(
-          "Failed to submit {} for execution. It will be re-attempted later.",
-          entry.description(),
-          e);
+      updateAttemptCount(entry, e);
     }
   }
 
@@ -312,7 +289,7 @@ public class TransactionOutbox {
                 args))
         .nextAttemptTime(
             LocalDateTime.ofInstant(
-                    clockProvider.getClock().instant(), clockProvider.getClock().getZone())
+                clockProvider.getClock().instant(), clockProvider.getClock().getZone())
                 .plus(attemptFrequency))
         .build();
   }
@@ -329,12 +306,22 @@ public class TransactionOutbox {
     }
   }
 
-  private void updateAttemptCount(TransactionOutboxEntry entry) {
+  private void updateAttemptCount(TransactionOutboxEntry entry, Throwable cause) {
     try {
       entry.setAttempts(entry.getAttempts() + 1);
-      entry.setBlacklisted(entry.getAttempts() >= blacklistAfterAttempts);
+      var blacklisted = entry.getAttempts() >= blacklistAfterAttempts;
+      entry.setBlacklisted(blacklisted);
       entry.setNextAttemptTime(now().plus(attemptFrequency));
       transactionManager.inTransactionThrows(transaction -> persistor.update(transaction, entry));
+      if (blacklisted) {
+        log.error("Blacklisting failing process after {} attempts: {}",
+            entry.getAttempts(),
+            entry.description(),
+            cause);
+        listener.blacklisted(entry, cause);
+      } else {
+        log.warn("Temporarily failed to process: {}", entry.description(), cause);
+      }
     } catch (Exception e) {
       log.error(
           "Failed to update attempt count for {}. It may be retried more times than expected.",

--- a/transactionoutbox-core/src/main/java/com/gruelbox/transactionoutbox/TransactionOutboxListener.java
+++ b/transactionoutbox-core/src/main/java/com/gruelbox/transactionoutbox/TransactionOutboxListener.java
@@ -17,5 +17,19 @@ public interface TransactionOutboxListener {
    *
    * @param entry The outbox entry completed.
    */
-  void success(TransactionOutboxEntry entry);
+  default void success(TransactionOutboxEntry entry) {
+    // No-op
+  }
+
+  /**
+   * Fired when a transaction outbox task has passed the maximum number of retries and has been
+   * blacklisted. This event is not guaranteed to fire in the event of a JVM failure or power loss.
+   * It is fired <em>after</em> the commit to the database marking the task as blacklisted.
+   *
+   * @param entry The outbox entry blacklisted.
+   * @param cause The cause of the most recent failure.
+   */
+  default void blacklisted(TransactionOutboxEntry entry, Throwable cause) {
+    // No-op
+  }
 }

--- a/transactionoutbox-core/src/test/java/com/gruelbox/transactionoutbox/TestDefaultInvocationSerializer.java
+++ b/transactionoutbox-core/src/test/java/com/gruelbox/transactionoutbox/TestDefaultInvocationSerializer.java
@@ -1,6 +1,7 @@
 package com.gruelbox.transactionoutbox;
 
 import java.io.StringReader;
+import java.io.StringWriter;
 import java.time.DayOfWeek;
 import java.time.Duration;
 import java.time.Instant;
@@ -140,7 +141,8 @@ class TestDefaultInvocationSerializer {
   }
 
   Invocation serdeser(Invocation invocation) {
-    String s = serializer.serialize(invocation);
-    return serializer.deserialize(new StringReader(s));
+    var writer = new StringWriter();
+    serializer.serializeInvocation(invocation, writer);
+    return serializer.deserializeInvocation(new StringReader(writer.toString()));
   }
 }

--- a/transactionoutbox-core/src/test/resources/logback-test.xml
+++ b/transactionoutbox-core/src/test/resources/logback-test.xml
@@ -5,7 +5,7 @@
       <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{5} - %msg%n</pattern>
     </encoder>
   </appender>
-  <root level="DEBUG">
+  <root level="INFO">
     <appender-ref ref="STDOUT" />
   </root>
 </configuration>

--- a/transactionoutbox-spring/src/main/java/com/gruelbox/transactionoutbox/SpringTransactionManager.java
+++ b/transactionoutbox-spring/src/main/java/com/gruelbox/transactionoutbox/SpringTransactionManager.java
@@ -32,10 +32,9 @@ public class SpringTransactionManager implements TransactionManager {
   }
 
   @Override
-  @Transactional(propagation = Propagation.MANDATORY)
-  public <E extends Exception> void requireTransaction(ThrowingTransactionalWork<E> work)
-      throws E, NoTransactionActiveException {
-    work.doWork(transactionInstance);
+  public <T, E extends Exception> T requireTransactionReturns(
+      ThrowingTransactionalSupplier<T, E> work) throws E, NoTransactionActiveException {
+    return work.doWork(transactionInstance);
   }
 
   private final class SpringTransaction implements Transaction {


### PR DESCRIPTION
* Provide a throwing version of TransactionManager.requireTransaction
* Allow SPI access to the InvocationSerializer and improve documentation
* Allow SPI access to DefaultPersistor allowing it to be extended and reconfigured
* Decouple TransactionOutbox from Executor, providing a pattern for creating remoting implementations
* Added guidance on creating a remoting Submitter implementation
* Fix blacklisting logic, add a listener for it and a test for it
* Add whitelisting support and guidance