### PR TITLE
Request id-based idempotency protection

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ A flexible implementation of the [Transaction Outbox Pattern](https://microservi
    1. [jOOQ](#jooq)
 1. [Set up the background worker](#set-up-the-background-worker)
 1. [Managing the "dead letter queue"](#managing-the-dead-letter-queue)
+1. [Idempotency protection](#idempotency-protection)
 1. [Configuration reference](#configuration-reference)
 1. [Stubbing in tests](#stubbing-in-tests)
 
@@ -241,6 +242,37 @@ transactionOutboxEntry.whitelist(entryId, context);
 
 A good approach here is to use the [`TransactionOutboxListener`](https://www.javadoc.io/doc/com.gruelbox/transactionoutbox-core/latest/com/gruelbox/transactionoutbox/TransactionOutboxListener.html) callback to post an [interactive Slack message](https://api.slack.com/legacy/interactive-messages) - this can operate as both the alert and the "button" allowing a support engineer to submit the work for reprocessing.
 
+## Idempotency protection
+
+A common use case for `TransactionOutbox` is to receive an incoming request (such as a message from a message queue), acknowledge it immediately and process it asynchronously, for example:
+
+```java
+public class FooEventHandler implements SQSEventHandler<ThingHappenedEvent> {
+
+  @Inject private TransactionOutbox outbox;
+
+  public void handle(ThingHappenedEvent event) {
+    outbox.schedule(FooService.class).handleEvent(event.getThingId());
+  }
+}
+```
+However, incoming transports, whether they be message queues or APIs, usually need to rely on idempotency in message handlers (for the same reason that outgoing requests from outbox also rely on idempotency). This means the above code could get called twice.
+
+As long as `FooService.handleEvent()` is idempotent itself, this is harmless, but we can't always assume this. The incoming message might be a broadcast, with no knowledge of the behaviour of handlers and therefore no way of pre-generating any new record ids the handler might need and passing them in the message.
+
+To protect against this, `TransactionOutbox` can automatically detect duplicate requests and reject them with `AlreadyScheduledException`. Records of requests are retained up to a configurable threshold (see below).
+
+To use this, use the call pattern:
+
+```java
+outbox.with()
+  .uniqueRequestId("context-clientid")
+  .schedule(Service.class)
+  .process("Foo");
+```
+
+Where `context-clientid` is a globally-unique identifier derived from the incoming request.  Such ids are usually available from queue middleware as message ids, or if not you can require as part of the incoming API (possibly with a tenant prefix to ensure global uniqueness across tenants).
+
 ## Configuration reference
 
 This example shows a number of other configuration options in action:
@@ -295,6 +327,9 @@ TransactionOutbox outbox = TransactionOutbox.builder()
     // is called will be recreated in the task when it runs. Very useful for tracking things like user ids and
     // request ids across invocations.
     .serializeMdc(true)
+    // Sets how long we should keep records of requests with a unique request id so duplicate requests
+    // can be rejected. Defaults to 7 days.
+    .retentionThreshold(Duration.ofDays(1))
     // We can intercept task successes, failures and blacklistings. The most common use is to catch blacklistings
     // and raise alerts for these to be investigated. A Slack interactive message is particularly effective here
     // since it can be wired up to call whitelist() automatically.

--- a/README.md
+++ b/README.md
@@ -234,6 +234,11 @@ To mark the work for reprocessing, just use [`TransactionOutbox.whitelist()`](ht
 ```
 transactionOutboxEntry.whitelist(entryId);
 ```
+Or if using a `TransactionManager` that relies on explicit context (such as a non-thread local) [`JooqTransactionManager`](https://www.javadoc.io/doc/com.gruelbox/transactionoutbox-jooq/latest/com/gruelbox/transactionoutbox/JooqTransactionManager.html):
+```
+transactionOutboxEntry.whitelist(entryId, context);
+```
+
 A good approach here is to use the [`TransactionOutboxListener`](https://www.javadoc.io/doc/com.gruelbox/transactionoutbox-core/latest/com/gruelbox/transactionoutbox/TransactionOutboxListener.html) callback to post an [interactive Slack message](https://api.slack.com/legacy/interactive-messages) - this can operate as both the alert and the "button" allowing a support engineer to submit the work for reprocessing.
 
 ## Configuration reference

--- a/transactionoutbox-core/src/main/java/com/gruelbox/transactionoutbox/AlreadyScheduledException.java
+++ b/transactionoutbox-core/src/main/java/com/gruelbox/transactionoutbox/AlreadyScheduledException.java
@@ -1,0 +1,9 @@
+package com.gruelbox.transactionoutbox;
+
+import java.time.Duration;
+
+/**
+ * Thrown when we attempt to schedule an invocation with a unique client id which has already been
+ * used within {@link TransactionOutbox.TransactionOutboxBuilder#retentionThreshold(Duration)}.
+ */
+public class AlreadyScheduledException extends RuntimeException {}

--- a/transactionoutbox-core/src/main/java/com/gruelbox/transactionoutbox/AlreadyScheduledException.java
+++ b/transactionoutbox-core/src/main/java/com/gruelbox/transactionoutbox/AlreadyScheduledException.java
@@ -6,4 +6,8 @@ import java.time.Duration;
  * Thrown when we attempt to schedule an invocation with a unique client id which has already been
  * used within {@link TransactionOutbox.TransactionOutboxBuilder#retentionThreshold(Duration)}.
  */
-public class AlreadyScheduledException extends RuntimeException {}
+public class AlreadyScheduledException extends RuntimeException {
+  AlreadyScheduledException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/transactionoutbox-core/src/main/java/com/gruelbox/transactionoutbox/Beta.java
+++ b/transactionoutbox-core/src/main/java/com/gruelbox/transactionoutbox/Beta.java
@@ -17,7 +17,7 @@ import java.lang.annotation.Target;
  * work during upgrades. However it is generally inadvisable for <i>libraries</i> (which get
  * included on users' CLASSPATHs, outside the library developers' control) to do so.
  */
-@Target({ElementType.TYPE, ElementType.METHOD, ElementType.CONSTRUCTOR })
+@Target({ElementType.TYPE, ElementType.METHOD, ElementType.CONSTRUCTOR})
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
 public @interface Beta {}

--- a/transactionoutbox-core/src/main/java/com/gruelbox/transactionoutbox/DefaultMigrationManager.java
+++ b/transactionoutbox-core/src/main/java/com/gruelbox/transactionoutbox/DefaultMigrationManager.java
@@ -29,7 +29,11 @@ class DefaultMigrationManager {
                   + "    attempts INT,\n"
                   + "    blacklisted BOOLEAN,\n"
                   + "    version INT\n"
-                  + ")"));
+                  + ")"),
+          new Migration(
+              2,
+              "Add unique request id",
+              "ALTER TABLE TXNO_OUTBOX ADD COLUMN uniqueRequestId VARCHAR(100) NULL UNIQUE AFTER id)"));
 
   static void migrate(TransactionManager transactionManager) {
     transactionManager.inTransaction(

--- a/transactionoutbox-core/src/main/java/com/gruelbox/transactionoutbox/DefaultMigrationManager.java
+++ b/transactionoutbox-core/src/main/java/com/gruelbox/transactionoutbox/DefaultMigrationManager.java
@@ -33,7 +33,13 @@ class DefaultMigrationManager {
           new Migration(
               2,
               "Add unique request id",
-              "ALTER TABLE TXNO_OUTBOX ADD COLUMN uniqueRequestId VARCHAR(100) NULL UNIQUE AFTER id)"));
+              "ALTER TABLE TXNO_OUTBOX ADD COLUMN uniqueRequestId VARCHAR(100) NULL UNIQUE"),
+          new Migration(
+              3, "Add processed flag", "ALTER TABLE TXNO_OUTBOX ADD COLUMN processed BOOLEAN"),
+          new Migration(
+              4,
+              "Add flush index",
+              "CREATE INDEX IX_TXNO_OUTBOX_1 ON TXNO_OUTBOX (processed, blacklisted, nextAttemptTime)"));
 
   static void migrate(TransactionManager transactionManager) {
     transactionManager.inTransaction(

--- a/transactionoutbox-core/src/main/java/com/gruelbox/transactionoutbox/DefaultPersistor.java
+++ b/transactionoutbox-core/src/main/java/com/gruelbox/transactionoutbox/DefaultPersistor.java
@@ -6,6 +6,7 @@ import java.io.StringWriter;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.sql.SQLIntegrityConstraintViolationException;
 import java.sql.SQLTimeoutException;
 import java.sql.Statement;
 import java.sql.Timestamp;
@@ -86,25 +87,31 @@ public class DefaultPersistor implements Persistor {
   @Override
   public void save(Transaction tx, TransactionOutboxEntry entry)
       throws SQLException, AlreadyScheduledException {
+    var insertSql =
+        "INSERT INTO "
+            + tableName
+            + " (id, uniqueRequestId, invocation, nextAttemptTime, attempts, blacklisted, processed, version) VALUES (?, ?, ?, ?, ?, ?, ?, ?)";
     var writer = new StringWriter();
     serializer.serializeInvocation(entry.getInvocation(), writer);
     if (entry.getUniqueRequestId() == null) {
-      PreparedStatement stmt =
-          tx.prepareBatchStatement("INSERT INTO " + tableName + " VALUES (?, ?, ?, ?, ?, ?)");
+      PreparedStatement stmt = tx.prepareBatchStatement(insertSql);
       setupInsert(entry, writer, stmt);
       stmt.addBatch();
       log.debug("Inserted {} in batch", entry.description());
     } else {
-      try (PreparedStatement stmt =
-          tx.connection()
-              .prepareStatement("INSERT INTO " + tableName + " VALUES (?, ?, ?, ?, ?, ?)")) {
+      try (PreparedStatement stmt = tx.connection().prepareStatement(insertSql)) {
         setupInsert(entry, writer, stmt);
         stmt.executeUpdate();
         log.debug("Inserted {} immediately", entry.description());
-      } catch (SQLException e) {
-        // TODO check for key violation and rethrow as AlreadyScheduledException
-        log.error("", e);
-        throw e;
+      } catch (SQLIntegrityConstraintViolationException e) {
+        throw new AlreadyScheduledException(
+            "Request " + entry.description() + " already exists", e);
+      } catch (Exception e) {
+        if (e.getClass().getName().equals("org.postgresql.util.PSQLException")
+            && e.getMessage().contains("constraint")) {
+          throw new AlreadyScheduledException(
+              "Request " + entry.description() + " already exists", e);
+        }
       }
     }
   }
@@ -118,7 +125,8 @@ public class DefaultPersistor implements Persistor {
     stmt.setTimestamp(4, Timestamp.from(entry.getNextAttemptTime()));
     stmt.setInt(5, entry.getAttempts());
     stmt.setBoolean(6, entry.isBlacklisted());
-    stmt.setInt(7, entry.getVersion());
+    stmt.setBoolean(7, entry.isProcessed());
+    stmt.setInt(8, entry.getVersion());
   }
 
   @Override
@@ -145,14 +153,15 @@ public class DefaultPersistor implements Persistor {
                 "UPDATE "
                     + tableName
                     + " "
-                    + "SET nextAttemptTime = ?, attempts = ?, blacklisted = ?, version = ? "
+                    + "SET nextAttemptTime = ?, attempts = ?, blacklisted = ?, processed = ?, version = ? "
                     + "WHERE id = ? and version = ?")) {
       stmt.setTimestamp(1, Timestamp.from(entry.getNextAttemptTime()));
       stmt.setInt(2, entry.getAttempts());
       stmt.setBoolean(3, entry.isBlacklisted());
-      stmt.setInt(4, entry.getVersion() + 1);
-      stmt.setString(5, entry.getId());
-      stmt.setInt(6, entry.getVersion());
+      stmt.setBoolean(4, entry.isProcessed());
+      stmt.setInt(5, entry.getVersion() + 1);
+      stmt.setString(6, entry.getId());
+      stmt.setInt(7, entry.getVersion());
       if (stmt.executeUpdate() != 1) {
         throw new OptimisticLockException();
       }
@@ -187,7 +196,7 @@ public class DefaultPersistor implements Persistor {
             "UPDATE "
                 + tableName
                 + " SET attempts = 0, blacklisted = false "
-                + "WHERE blacklisted = true AND id = ?");
+                + "WHERE blacklisted = true AND processed = false AND id = ?");
     stmt.setString(1, entryId);
     stmt.setQueryTimeout(writeLockTimeoutSeconds);
     return stmt.executeUpdate() != 0;
@@ -200,12 +209,24 @@ public class DefaultPersistor implements Persistor {
         tx.connection()
             .prepareStatement(
                 // language=MySQL
-                "SELECT id, invocation, nextAttemptTime, attempts, blacklisted, version FROM "
+                "SELECT id, uniqueRequestId, invocation, nextAttemptTime, attempts, blacklisted, processed, version FROM "
                     + tableName
-                    + " WHERE nextAttemptTime < ? AND blacklisted = false LIMIT ?")) {
+                    + " WHERE nextAttemptTime < ? AND blacklisted = false AND processed = false LIMIT ?")) {
       stmt.setTimestamp(1, Timestamp.from(now));
       stmt.setInt(2, batchSize);
       return gatherResults(batchSize, stmt);
+    }
+  }
+
+  @Override
+  public int deleteProcessedAndExpired(Transaction tx, int batchSize, Instant now)
+      throws Exception {
+    try (PreparedStatement stmt =
+        tx.connection()
+            .prepareStatement(dialect.getDeleteExpired().replace("{{table}}", tableName))) {
+      stmt.setTimestamp(1, Timestamp.from(now));
+      stmt.setInt(2, batchSize);
+      return stmt.executeUpdate();
     }
   }
 
@@ -238,10 +259,12 @@ public class DefaultPersistor implements Persistor {
       TransactionOutboxEntry entry =
           TransactionOutboxEntry.builder()
               .id(rs.getString("id"))
+              .uniqueRequestId(rs.getString("uniqueRequestId"))
               .invocation(serializer.deserializeInvocation(invocationStream))
               .nextAttemptTime(rs.getTimestamp("nextAttemptTime").toInstant())
               .attempts(rs.getInt("attempts"))
               .blacklisted(rs.getBoolean("blacklisted"))
+              .processed(rs.getBoolean("processed"))
               .version(rs.getInt("version"))
               .build();
       log.debug("Found {}", entry);

--- a/transactionoutbox-core/src/main/java/com/gruelbox/transactionoutbox/Dialect.java
+++ b/transactionoutbox-core/src/main/java/com/gruelbox/transactionoutbox/Dialect.java
@@ -11,11 +11,20 @@ import lombok.Getter;
  */
 @AllArgsConstructor
 @Getter
+@Beta
 public enum Dialect {
-  MY_SQL_5(false),
-  MY_SQL_8(true),
-  POSTGRESQL_9(true),
-  H2(false);
+  MY_SQL_5(
+      false,
+      "DELETE FROM {{table}} WHERE nextAttemptTime < ? AND processed = true AND blacklisted = false LIMIT ?"),
+  MY_SQL_8(
+      true,
+      "DELETE FROM {{table}} WHERE nextAttemptTime < ? AND processed = true AND blacklisted = false LIMIT ?"),
+  POSTGRESQL_9(
+      true,
+      "DELETE FROM {{table}} WHERE ctid IN (SELECT ctid FROM {{table}} WHERE nextAttemptTime < ? AND processed = true AND blacklisted = false LIMIT ?)"),
+  H2(
+      false,
+      "DELETE FROM {{table}} WHERE nextAttemptTime < ? AND processed = true AND blacklisted = false LIMIT ?");
 
   /**
    * @return True if hot row support ({@code SKIP LOCKED}) is available, increasing performance when
@@ -24,4 +33,8 @@ public enum Dialect {
    */
   @SuppressWarnings("JavaDoc")
   private final boolean supportsSkipLock;
+
+  /** @return Format string for the SQL required to delete expired retained records. */
+  @SuppressWarnings("JavaDoc")
+  private final String deleteExpired;
 }

--- a/transactionoutbox-core/src/main/java/com/gruelbox/transactionoutbox/Persistor.java
+++ b/transactionoutbox-core/src/main/java/com/gruelbox/transactionoutbox/Persistor.java
@@ -31,7 +31,9 @@ public interface Persistor {
   void migrate(TransactionManager transactionManager);
 
   /**
-   * Saves a new {@link TransactionOutboxEntry}.
+   * Saves a new {@link TransactionOutboxEntry}. Should throw {@link AlreadyScheduledException} if
+   * the record already exists based on the {@code id} or {@code uniqueRequestId} (the latter of
+   * which should not treat nulls as duplicates).
    *
    * @param tx The current {@link Transaction}.
    * @param entry The entry to save. All properties on the object should be saved recursively.

--- a/transactionoutbox-core/src/main/java/com/gruelbox/transactionoutbox/Persistor.java
+++ b/transactionoutbox-core/src/main/java/com/gruelbox/transactionoutbox/Persistor.java
@@ -104,4 +104,6 @@ public interface Persistor {
    */
   List<TransactionOutboxEntry> selectBatch(Transaction tx, int batchSize, Instant now)
       throws Exception;
+
+  int deleteProcessedAndExpired(Transaction tx, int batchSize, Instant now) throws Exception;
 }

--- a/transactionoutbox-core/src/main/java/com/gruelbox/transactionoutbox/StubPersistor.java
+++ b/transactionoutbox-core/src/main/java/com/gruelbox/transactionoutbox/StubPersistor.java
@@ -44,4 +44,9 @@ public class StubPersistor implements Persistor {
   public List<TransactionOutboxEntry> selectBatch(Transaction tx, int batchSize, Instant now) {
     return List.of();
   }
+
+  @Override
+  public int deleteProcessedAndExpired(Transaction tx, int batchSize, Instant now) {
+    return 0;
+  }
 }

--- a/transactionoutbox-core/src/main/java/com/gruelbox/transactionoutbox/ThreadLocalContextTransactionManager.java
+++ b/transactionoutbox-core/src/main/java/com/gruelbox/transactionoutbox/ThreadLocalContextTransactionManager.java
@@ -11,7 +11,8 @@ import java.lang.reflect.Method;
  *
  * <p>Call pattern permitted:
  *
- * <pre>transactionManager.inTransaction(() -&gt; outbox.schedule(MyClass.ckass).myMethod("foo");</pre>
+ * <pre>transactionManager.inTransaction(() -&gt; outbox.schedule(MyClass.ckass).myMethod("foo");
+ * </pre>
  *
  * <p>Adds the {@link #requireTransactionReturns(ThrowingTransactionalSupplier)} and {@link
  * #requireTransaction(ThrowingTransactionalWork)} methods, which extract the current transaction

--- a/transactionoutbox-core/src/main/java/com/gruelbox/transactionoutbox/TransactionOutboxEntry.java
+++ b/transactionoutbox-core/src/main/java/com/gruelbox/transactionoutbox/TransactionOutboxEntry.java
@@ -78,6 +78,17 @@ public class TransactionOutboxEntry {
   private boolean blacklisted;
 
   /**
+   * @param processed True if the task has been processed but has been retained to prevent duplicate
+   *     requests.
+   * @return True if the task has been processed but has been retained to prevent * duplicate
+   *     requests.
+   */
+  @SuppressWarnings("JavaDoc")
+  @Getter
+  @Setter
+  private boolean processed;
+
+  /**
    * @param version The optimistic locking version. Monotonically increasing with each update.
    * @return The optimistic locking version. Monotonically increasing with each update.
    */
@@ -97,11 +108,12 @@ public class TransactionOutboxEntry {
         if (!this.initialized) {
           String description =
               String.format(
-                  "%s.%s(%s) [%s]",
+                  "%s.%s(%s) [%s]%s",
                   invocation.getClassName(),
                   invocation.getMethodName(),
                   Arrays.stream(invocation.getArgs()).map(this::stringify).collect(joining(", ")),
-                  id);
+                  id,
+                  uniqueRequestId == null ? "" : " uid=[" + uniqueRequestId + "]");
           this.description = description;
           this.initialized = true;
           return description;

--- a/transactionoutbox-core/src/main/java/com/gruelbox/transactionoutbox/TransactionOutboxEntry.java
+++ b/transactionoutbox-core/src/main/java/com/gruelbox/transactionoutbox/TransactionOutboxEntry.java
@@ -32,6 +32,14 @@ public class TransactionOutboxEntry {
   private final String id;
 
   /**
+   * @param uniqueRequestId A unique, client-supplied key for the entry. If supplied, it must be
+   *     globally unique
+   */
+  @SuppressWarnings("JavaDoc")
+  @Getter
+  private final String uniqueRequestId;
+
+  /**
    * @param invocation The method invocation to perform.
    * @return The method invocation to perform.
    */

--- a/transactionoutbox-core/src/test/java/com/gruelbox/transactionoutbox/TestDefaultPersistorH2.java
+++ b/transactionoutbox-core/src/test/java/com/gruelbox/transactionoutbox/TestDefaultPersistorH2.java
@@ -1,0 +1,27 @@
+package com.gruelbox.transactionoutbox;
+
+import lombok.extern.slf4j.Slf4j;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@Slf4j
+@Testcontainers
+class TestDefaultPersistorH2 extends AbstractDefaultPersistorTest {
+
+  private DefaultPersistor persistor = DefaultPersistor.builder().dialect(Dialect.H2).build();
+  private TransactionManager txManager =
+      TransactionManager.fromConnectionDetails(
+          "org.h2.Driver",
+          "jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;DEFAULT_LOCK_TIMEOUT=2000;LOB_TIMEOUT=2000;MV_STORE=TRUE",
+          "test",
+          "test");
+
+  @Override
+  protected DefaultPersistor persistor() {
+    return persistor;
+  }
+
+  @Override
+  protected TransactionManager txManager() {
+    return txManager;
+  }
+}

--- a/transactionoutbox-core/src/test/java/com/gruelbox/transactionoutbox/acceptance/AbstractAcceptanceTest.java
+++ b/transactionoutbox-core/src/test/java/com/gruelbox/transactionoutbox/acceptance/AbstractAcceptanceTest.java
@@ -174,7 +174,7 @@ abstract class AbstractAcceptanceTest {
     // Run the clock forward to just under the retention threshold
     clockProvider.set(
         Clock.fixed(
-            clockProvider.get().instant().plus(Duration.ofDays(2)).minusSeconds(30),
+            clockProvider.get().instant().plus(Duration.ofDays(2)).minusSeconds(60),
             clockProvider.get().getZone()));
     outbox.flush();
 
@@ -201,7 +201,7 @@ abstract class AbstractAcceptanceTest {
 
     // Run the clock over the threshold
     clockProvider.set(
-        Clock.fixed(clockProvider.get().instant().plusSeconds(60), clockProvider.get().getZone()));
+        Clock.fixed(clockProvider.get().instant().plusSeconds(120), clockProvider.get().getZone()));
     outbox.flush();
 
     // We should now be able to add the work

--- a/transactionoutbox-guice/src/test/java/com.gruelbox.transactionoutbox.acceptance/TestGuiceBinding.java
+++ b/transactionoutbox-guice/src/test/java/com.gruelbox.transactionoutbox.acceptance/TestGuiceBinding.java
@@ -1,5 +1,7 @@
 package com.gruelbox.transactionoutbox.acceptance;
 
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import com.google.inject.AbstractModule;
 import com.google.inject.BindingAnnotation;
 import com.google.inject.Guice;
@@ -15,16 +17,13 @@ import com.gruelbox.transactionoutbox.TransactionManager;
 import com.gruelbox.transactionoutbox.TransactionOutbox;
 import com.gruelbox.transactionoutbox.TransactionOutboxEntry;
 import com.gruelbox.transactionoutbox.TransactionOutboxListener;
-import lombok.extern.slf4j.Slf4j;
-import org.junit.jupiter.api.Test;
-
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import java.util.concurrent.atomic.AtomicBoolean;
-
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Test;
 
 /**
  * Demonstrates an alternative approach to using {@link TransactionOutbox} using binding annotations
@@ -33,19 +32,13 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 @Slf4j
 class TestGuiceBinding {
 
-  /**
-   * The real service
-   */
+  /** The real service */
   @Inject MyService local;
 
-  /**
-   * The remoted version
-   */
+  /** The remoted version */
   @Inject @Remote MyService remote;
 
-  /**
-   * We need this to schedule the work
-   */
+  /** We need this to schedule the work */
   @Inject TransactionManager transactionManager;
 
   @Test
@@ -54,18 +47,17 @@ class TestGuiceBinding {
     Injector injector = Guice.createInjector(new DemoModule(processedWithRemote));
     injector.injectMembers(this);
 
-    transactionManager.inTransaction(() -> {
-      remote.process();
-      log.info("Queued request");
-    });
+    transactionManager.inTransaction(
+        () -> {
+          remote.process();
+          log.info("Queued request");
+        });
 
     assertTrue(processedWithRemote.get());
     assertTrue(local.processed.get());
   }
 
-  /**
-   * The service we're going to remote
-   */
+  /** The service we're going to remote */
   static class MyService {
     AtomicBoolean processed = new AtomicBoolean();
 
@@ -75,17 +67,13 @@ class TestGuiceBinding {
     }
   }
 
-  /**
-   * Binding annotation for the remote version of the service.
-   */
+  /** Binding annotation for the remote version of the service. */
   @Target({ElementType.PARAMETER, ElementType.METHOD, ElementType.FIELD})
   @Retention(RetentionPolicy.RUNTIME)
   @BindingAnnotation
   public @interface Remote {}
 
-  /**
-   * Sets up the bindings
-   */
+  /** Sets up the bindings */
   static final class DemoModule extends AbstractModule {
 
     private final AtomicBoolean processedWithRemote;
@@ -108,12 +96,13 @@ class TestGuiceBinding {
           .persistor(StubPersistor.builder().build())
           .submitter(Submitter.withExecutor(Runnable::run))
           .transactionManager(transactionManager)
-          .listener(new TransactionOutboxListener() {
-            @Override
-            public void success(TransactionOutboxEntry entry) {
-              processedWithRemote.set(true);
-            }
-          })
+          .listener(
+              new TransactionOutboxListener() {
+                @Override
+                public void success(TransactionOutboxEntry entry) {
+                  processedWithRemote.set(true);
+                }
+              })
           .build();
     }
 

--- a/transactionoutbox-jooq/src/main/java/com/gruelbox/transactionoutbox/ThreadLocalJooqTransactionManager.java
+++ b/transactionoutbox-jooq/src/main/java/com/gruelbox/transactionoutbox/ThreadLocalJooqTransactionManager.java
@@ -6,8 +6,8 @@ import org.jooq.DSLContext;
 
 /**
  * jOOQ transaction manager which uses thread-local context. Best used with {@link
- * org.jooq.impl.ThreadLocalTransactionProvider}. Relies on a {@link JooqTransactionListener}
- * being attached to the {@link DSLContext}.
+ * org.jooq.impl.ThreadLocalTransactionProvider}. Relies on a {@link JooqTransactionListener} being
+ * attached to the {@link DSLContext}.
  */
 @Slf4j
 final class ThreadLocalJooqTransactionManager

--- a/transactionoutbox-jooq/src/test/java/com/gruelbox/transactionoutbox/acceptance/TestJooqTransactionManagerWithDefaultProviderAndExplicitlyPassedContext.java
+++ b/transactionoutbox-jooq/src/test/java/com/gruelbox/transactionoutbox/acceptance/TestJooqTransactionManagerWithDefaultProviderAndExplicitlyPassedContext.java
@@ -66,7 +66,7 @@ class TestJooqTransactionManagerWithDefaultProviderAndExplicitlyPassedContext {
   private HikariDataSource pooledDataSource() {
     HikariConfig config = new HikariConfig();
     config.setJdbcUrl(
-        "jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;DEFAULT_LOCK_TIMEOUT=60000;LOB_TIMEOUT=2000;MV_STORE=TRUE");
+        "jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;DEFAULT_LOCK_TIMEOUT=2000;LOB_TIMEOUT=2000;MV_STORE=TRUE");
     config.setUsername("test");
     config.setPassword("test");
     config.addDataSourceProperty("cachePrepStmts", "true");

--- a/transactionoutbox-jooq/src/test/java/com/gruelbox/transactionoutbox/acceptance/TestJooqTransactionManagerWithDefaultProviderAndThreadLocalContext.java
+++ b/transactionoutbox-jooq/src/test/java/com/gruelbox/transactionoutbox/acceptance/TestJooqTransactionManagerWithDefaultProviderAndThreadLocalContext.java
@@ -73,7 +73,7 @@ class TestJooqTransactionManagerWithDefaultProviderAndThreadLocalContext {
   private HikariDataSource pooledDataSource() {
     HikariConfig config = new HikariConfig();
     config.setJdbcUrl(
-        "jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;DEFAULT_LOCK_TIMEOUT=60000;LOB_TIMEOUT=2000;MV_STORE=TRUE");
+        "jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;DEFAULT_LOCK_TIMEOUT=2000;LOB_TIMEOUT=2000;MV_STORE=TRUE");
     config.setUsername("test");
     config.setPassword("test");
     config.addDataSourceProperty("cachePrepStmts", "true");

--- a/transactionoutbox-jooq/src/test/java/com/gruelbox/transactionoutbox/acceptance/TestJooqTransactionManagerWithThreadLocalProvider.java
+++ b/transactionoutbox-jooq/src/test/java/com/gruelbox/transactionoutbox/acceptance/TestJooqTransactionManagerWithThreadLocalProvider.java
@@ -9,8 +9,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
-import com.gruelbox.transactionoutbox.DefaultInvocationSerializer;
-import com.gruelbox.transactionoutbox.DefaultPersistor;
 import com.gruelbox.transactionoutbox.Dialect;
 import com.gruelbox.transactionoutbox.Instantiator;
 import com.gruelbox.transactionoutbox.JooqTransactionListener;
@@ -28,7 +26,6 @@ import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
-import java.util.Set;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;

--- a/transactionoutbox-jooq/src/test/java/com/gruelbox/transactionoutbox/acceptance/TestJooqTransactionManagerWithThreadLocalProvider.java
+++ b/transactionoutbox-jooq/src/test/java/com/gruelbox/transactionoutbox/acceptance/TestJooqTransactionManagerWithThreadLocalProvider.java
@@ -76,7 +76,7 @@ class TestJooqTransactionManagerWithThreadLocalProvider {
   private HikariDataSource pooledDataSource() {
     HikariConfig config = new HikariConfig();
     config.setJdbcUrl(
-        "jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;DEFAULT_LOCK_TIMEOUT=60000;LOB_TIMEOUT=2000;MV_STORE=TRUE");
+        "jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;DEFAULT_LOCK_TIMEOUT=2000;LOB_TIMEOUT=2000;MV_STORE=TRUE");
     config.setUsername("test");
     config.setPassword("test");
     config.addDataSourceProperty("cachePrepStmts", "true");

--- a/transactionoutbox-spring/src/main/java/com/gruelbox/transactionoutbox/SpringTransactionManager.java
+++ b/transactionoutbox-spring/src/main/java/com/gruelbox/transactionoutbox/SpringTransactionManager.java
@@ -15,9 +15,7 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.support.TransactionSynchronizationAdapter;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
 
-/**
- * Transaction manager which uses spring-tx and Hibernate.
- */
+/** Transaction manager which uses spring-tx and Hibernate. */
 @Beta
 @Slf4j
 @Service

--- a/transactionoutbox-spring/src/main/java/com/gruelbox/transactionoutbox/SpringTransactionOutboxFactory.java
+++ b/transactionoutbox-spring/src/main/java/com/gruelbox/transactionoutbox/SpringTransactionOutboxFactory.java
@@ -4,7 +4,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 /**
- * @deprecated Use {@link SpringInstantiator} and {@link SpringTransactionManager} as per the README.
+ * @deprecated Use {@link SpringInstantiator} and {@link SpringTransactionManager} as per the
+ *     README.
  */
 @Service
 @Deprecated

--- a/transactionoutbox-spring/src/test/java/com/gruelbox/transactionoutbox/acceptance/TransactionOutboxSpringDemoApplication.java
+++ b/transactionoutbox-spring/src/test/java/com/gruelbox/transactionoutbox/acceptance/TransactionOutboxSpringDemoApplication.java
@@ -19,8 +19,8 @@ public class TransactionOutboxSpringDemoApplication {
 
   @Bean
   @Lazy
-  public TransactionOutbox transactionOutbox(SpringInstantiator instantiator,
-                                             SpringTransactionManager transactionManager) {
+  public TransactionOutbox transactionOutbox(
+      SpringInstantiator instantiator, SpringTransactionManager transactionManager) {
     return TransactionOutbox.builder()
         .instantiator(instantiator)
         .transactionManager(transactionManager)


### PR DESCRIPTION
A common use case for outbox is to _receive_ an incoming request (such as a message from a message queue), acknowledge it and process it asynchronously. However such transports usually need to rely on idempotency in message handlers (for the same reason that outgoing requests from outbox also rely on idempotency) which could mean two outbox tasks getting scheduled for the same work. This is fine if the outbox request is itself idempotent, but this is not always possible (the incoming request may be an event with no knowledge of the processing it triggers, and the processing needs to assign new ids for records created).

To protect against this, this enhancement adds a call pattern:

```
outbox.with()
  .uniqueRequestId("context-clientid")
  .schedule(Service.class)
  .process("Foo");
```

This will throw an `AlreadyScheduledException` if the request has already been made. Such requests will be remembered up to a configurable retention threshold before being evicted.

This **also** fixes a performance issue due to lack of indexes on the `TXNO_OUTBOX` table.