### PR TITLE
Increase use of SKIP LOCKED to the batch selection

### DIFF
--- a/transactionoutbox-core/src/main/java/com/gruelbox/transactionoutbox/Dialect.java
+++ b/transactionoutbox-core/src/main/java/com/gruelbox/transactionoutbox/Dialect.java
@@ -13,18 +13,12 @@ import lombok.Getter;
 @Getter
 @Beta
 public enum Dialect {
-  MY_SQL_5(
-      false,
-      "DELETE FROM {{table}} WHERE nextAttemptTime < ? AND processed = true AND blacklisted = false LIMIT ?"),
-  MY_SQL_8(
-      true,
-      "DELETE FROM {{table}} WHERE nextAttemptTime < ? AND processed = true AND blacklisted = false LIMIT ?"),
+  MY_SQL_5(false, Constants.DEFAULT_DELETE_EXPIRED_STMT),
+  MY_SQL_8(true, Constants.DEFAULT_DELETE_EXPIRED_STMT),
   POSTGRESQL_9(
       true,
       "DELETE FROM {{table}} WHERE ctid IN (SELECT ctid FROM {{table}} WHERE nextAttemptTime < ? AND processed = true AND blacklisted = false LIMIT ?)"),
-  H2(
-      false,
-      "DELETE FROM {{table}} WHERE nextAttemptTime < ? AND processed = true AND blacklisted = false LIMIT ?");
+  H2(false, Constants.DEFAULT_DELETE_EXPIRED_STMT);
 
   /**
    * @return True if hot row support ({@code SKIP LOCKED}) is available, increasing performance when
@@ -37,4 +31,9 @@ public enum Dialect {
   /** @return Format string for the SQL required to delete expired retained records. */
   @SuppressWarnings("JavaDoc")
   private final String deleteExpired;
+
+  private static class Constants {
+    static final String DEFAULT_DELETE_EXPIRED_STMT =
+        "DELETE FROM {{table}} WHERE nextAttemptTime < ? AND processed = true AND blacklisted = false LIMIT ?";
+  }
 }

--- a/transactionoutbox-core/src/test/java/com/gruelbox/transactionoutbox/TestDefaultPersistorH2.java
+++ b/transactionoutbox-core/src/test/java/com/gruelbox/transactionoutbox/TestDefaultPersistorH2.java
@@ -24,4 +24,9 @@ class TestDefaultPersistorH2 extends AbstractDefaultPersistorTest {
   protected TransactionManager txManager() {
     return txManager;
   }
+
+  @Override
+  protected Dialect dialect() {
+    return Dialect.H2;
+  }
 }

--- a/transactionoutbox-core/src/test/java/com/gruelbox/transactionoutbox/TestDefaultPersistorMySql8.java
+++ b/transactionoutbox-core/src/test/java/com/gruelbox/transactionoutbox/TestDefaultPersistorMySql8.java
@@ -9,14 +9,14 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 
 @Slf4j
 @Testcontainers
-class TestDefaultPersistorMySql5 extends AbstractDefaultPersistorTest {
+class TestDefaultPersistorMySql8 extends AbstractDefaultPersistorTest {
 
   @Container
   @SuppressWarnings("rawtypes")
   private static final JdbcDatabaseContainer container =
-      new MySQLContainer<>("mysql:5").withStartupTimeout(Duration.ofHours(1));
+      new MySQLContainer<>("mysql:8").withStartupTimeout(Duration.ofHours(1));
 
-  private DefaultPersistor persistor = DefaultPersistor.builder().dialect(Dialect.MY_SQL_5).build();
+  private DefaultPersistor persistor = DefaultPersistor.builder().dialect(Dialect.MY_SQL_8).build();
   private TransactionManager txManager =
       TransactionManager.fromConnectionDetails(
           "com.mysql.cj.jdbc.Driver",

--- a/transactionoutbox-core/src/test/java/com/gruelbox/transactionoutbox/TestDefaultPersistorPostgres10.java
+++ b/transactionoutbox-core/src/test/java/com/gruelbox/transactionoutbox/TestDefaultPersistorPostgres10.java
@@ -35,4 +35,9 @@ class TestDefaultPersistorPostgres10 extends AbstractDefaultPersistorTest {
   protected TransactionManager txManager() {
     return txManager;
   }
+
+  @Override
+  protected Dialect dialect() {
+    return Dialect.POSTGRESQL_9;
+  }
 }


### PR DESCRIPTION
Should make high-contention polling across multiple instances largely conflict-free on Postgres and MySQL 8+.