### PR TITLE
Add scheduled listener hook

### DIFF
--- a/transactionoutbox-core/src/main/java/com/gruelbox/transactionoutbox/TransactionOutbox.java
+++ b/transactionoutbox-core/src/main/java/com/gruelbox/transactionoutbox/TransactionOutbox.java
@@ -269,7 +269,13 @@ public class TransactionOutbox {
                           uniqueRequestId);
                   validator.validate(entry);
                   persistor.save(extracted.getTransaction(), entry);
-                  extracted.getTransaction().addPostCommitHook(() -> submitNow(entry));
+                  extracted
+                      .getTransaction()
+                      .addPostCommitHook(
+                          () -> {
+                            listener.scheduled(entry);
+                            submitNow(entry);
+                          });
                   log.debug(
                       "Scheduled {} for running after transaction commit", entry.description());
                   return null;


### PR DESCRIPTION
Main use case is for acceptance tests that need to track work submitted, failed and completed to determine whether to wait for the application to reach a consistent state.