### PR TITLE
Reduce logging when flushing stale tasks

### DIFF
--- a/transactionoutbox-core/src/main/java/com/gruelbox/transactionoutbox/TransactionOutbox.java
+++ b/transactionoutbox-core/src/main/java/com/gruelbox/transactionoutbox/TransactionOutbox.java
@@ -155,7 +155,7 @@ public class TransactionOutbox {
   }
 
   private List<TransactionOutboxEntry> flush(Instant now) {
-    log.info("Flushing stale tasks");
+    log.debug("Flushing stale tasks");
     var batch =
         transactionManager.inTransactionReturns(
             transaction -> {


### PR DESCRIPTION
When flushing tasks, a log line is printed stating `Flushing stale tasks`. I believe this is better suited to debug level.