### PR TITLE
Delay migration until outbox is actually used, to avoid race conditions with app startup

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
     <logback.version>1.2.3</logback.version>
     <revision>1.3.99999-SNAPSHOT</revision>
     <junit.jupiter.version>5.7.0</junit.jupiter.version>
-    <testcontainers.version>1.14.3</testcontainers.version>
+    <testcontainers.version>1.15.0</testcontainers.version>
   </properties>
 
   <modules>

--- a/transactionoutbox-core/src/main/java/com/gruelbox/transactionoutbox/DefaultPersistor.java
+++ b/transactionoutbox-core/src/main/java/com/gruelbox/transactionoutbox/DefaultPersistor.java
@@ -284,7 +284,7 @@ public class DefaultPersistor implements Persistor {
   }
 
   // For testing. Assumed low volume.
-  void clear(Transaction tx) throws SQLException {
+  public void clear(Transaction tx) throws SQLException {
     try (Statement stmt = tx.connection().createStatement()) {
       stmt.execute("DELETE FROM " + tableName);
     }

--- a/transactionoutbox-core/src/main/java/com/gruelbox/transactionoutbox/TransactionOutboxImpl.java
+++ b/transactionoutbox-core/src/main/java/com/gruelbox/transactionoutbox/TransactionOutboxImpl.java
@@ -1,0 +1,369 @@
+package com.gruelbox.transactionoutbox;
+
+import static com.gruelbox.transactionoutbox.Utils.logAtLevel;
+import static com.gruelbox.transactionoutbox.Utils.uncheckedly;
+import static java.time.temporal.ChronoUnit.MILLIS;
+import static java.time.temporal.ChronoUnit.MINUTES;
+
+import java.lang.reflect.InvocationTargetException;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import javax.validation.ClockProvider;
+import javax.validation.Valid;
+import javax.validation.constraints.Min;
+import javax.validation.constraints.NotNull;
+import lombok.ToString;
+import lombok.extern.slf4j.Slf4j;
+import org.hibernate.validator.constraints.Length;
+import org.hibernate.validator.internal.engine.DefaultClockProvider;
+import org.slf4j.MDC;
+import org.slf4j.event.Level;
+
+@Slf4j
+class TransactionOutboxImpl implements TransactionOutbox {
+
+  private static final int DEFAULT_FLUSH_BATCH_SIZE = 4096;
+
+  @NotNull private final TransactionManager transactionManager;
+  @Valid @NotNull private final Persistor persistor;
+  @Valid @NotNull private final Instantiator instantiator;
+  @NotNull private final Submitter submitter;
+  @NotNull private final Duration attemptFrequency;
+  @NotNull private final Level logLevelTemporaryFailure;
+
+  @Min(1)
+  private final int blockAfterAttempts;
+
+  @Min(1)
+  private final int flushBatchSize;
+
+  @NotNull private final ClockProvider clockProvider;
+  @NotNull private final TransactionOutboxListener listener;
+  private final boolean serializeMdc;
+  private final Validator validator;
+  @NotNull private final Duration retentionThreshold;
+
+  private TransactionOutboxImpl(
+      TransactionManager transactionManager,
+      Instantiator instantiator,
+      Submitter submitter,
+      Duration attemptFrequency,
+      int blockAfterAttempts,
+      int flushBatchSize,
+      ClockProvider clockProvider,
+      TransactionOutboxListener listener,
+      Persistor persistor,
+      Level logLevelTemporaryFailure,
+      Boolean serializeMdc,
+      Duration retentionThreshold) {
+    this.transactionManager = transactionManager;
+    this.instantiator = Utils.firstNonNull(instantiator, Instantiator::usingReflection);
+    this.persistor = persistor;
+    this.submitter = Utils.firstNonNull(submitter, Submitter::withDefaultExecutor);
+    this.attemptFrequency = Utils.firstNonNull(attemptFrequency, () -> Duration.of(2, MINUTES));
+    this.blockAfterAttempts = blockAfterAttempts < 1 ? 5 : blockAfterAttempts;
+    this.flushBatchSize = flushBatchSize < 1 ? DEFAULT_FLUSH_BATCH_SIZE : flushBatchSize;
+    this.clockProvider = Utils.firstNonNull(clockProvider, () -> DefaultClockProvider.INSTANCE);
+    this.listener = Utils.firstNonNull(listener, () -> new TransactionOutboxListener() {});
+    this.logLevelTemporaryFailure = Utils.firstNonNull(logLevelTemporaryFailure, () -> Level.WARN);
+    this.validator = new Validator(this.clockProvider);
+    this.serializeMdc = serializeMdc == null || serializeMdc;
+    this.retentionThreshold = retentionThreshold == null ? Duration.ofDays(7) : retentionThreshold;
+    this.validator.validate(this);
+    this.persistor.migrate(transactionManager);
+  }
+
+  static TransactionOutboxBuilder builder() {
+    return new TransactionOutboxBuilderImpl();
+  }
+
+  @Override
+  public <T> T schedule(Class<T> clazz) {
+    return schedule(clazz, null);
+  }
+
+  @Override
+  public ParameterizedScheduleBuilder with() {
+    return new ParameterizedScheduleBuilderImpl();
+  }
+
+  @SuppressWarnings("UnusedReturnValue")
+  @Override
+  public boolean flush() {
+    Instant now = clockProvider.getClock().instant();
+    List<TransactionOutboxEntry> batch = flush(now);
+    expireIdempotencyProtection(now);
+    return !batch.isEmpty();
+  }
+
+  private List<TransactionOutboxEntry> flush(Instant now) {
+    log.debug("Flushing stale tasks");
+    var batch =
+        transactionManager.inTransactionReturns(
+            transaction -> {
+              List<TransactionOutboxEntry> result = new ArrayList<>(flushBatchSize);
+              uncheckedly(() -> persistor.selectBatch(transaction, flushBatchSize, now))
+                  .forEach(
+                      entry -> {
+                        log.debug("Reprocessing {}", entry.description());
+                        try {
+                          pushBack(transaction, entry);
+                          result.add(entry);
+                        } catch (OptimisticLockException e) {
+                          log.debug("Beaten to optimistic lock on {}", entry.description());
+                        }
+                      });
+              return result;
+            });
+    log.debug("Got batch of {}", batch.size());
+    batch.forEach(this::submitNow);
+    log.debug("Submitted batch");
+    return batch;
+  }
+
+  private void expireIdempotencyProtection(Instant now) {
+    long totalRecordsDeleted = 0;
+    int recordsDeleted;
+    do {
+      recordsDeleted =
+          transactionManager.inTransactionReturns(
+              tx ->
+                  uncheckedly(() -> persistor.deleteProcessedAndExpired(tx, flushBatchSize, now)));
+      totalRecordsDeleted += recordsDeleted;
+    } while (recordsDeleted > 0);
+    if (totalRecordsDeleted > 0) {
+      long s = retentionThreshold.toSeconds();
+      String duration = String.format("%dd:%02dh:%02dm", s / 3600, (s % 3600) / 60, (s % 60));
+      log.info(
+          "Expired idempotency protection on {} requests completed more than {} ago",
+          totalRecordsDeleted,
+          duration);
+    } else {
+      log.debug("No records found to delete as of {}", now);
+    }
+  }
+
+  @Override
+  public boolean unblock(String entryId) {
+    if (!(transactionManager instanceof ThreadLocalContextTransactionManager)) {
+      throw new UnsupportedOperationException(
+          "This method requires a ThreadLocalContextTransactionManager");
+    }
+    log.info("Unblocking entry {} for retry.", entryId);
+    try {
+      return ((ThreadLocalContextTransactionManager) transactionManager)
+          .requireTransactionReturns(tx -> persistor.unblock(tx, entryId));
+    } catch (Exception e) {
+      throw (RuntimeException) Utils.uncheckAndThrow(e);
+    }
+  }
+
+  @Override
+  @SuppressWarnings({"unchecked", "rawtypes"})
+  public boolean unblock(String entryId, Object transactionContext) {
+    if (!(transactionManager instanceof ParameterContextTransactionManager)) {
+      throw new UnsupportedOperationException(
+          "This method requires a ParameterContextTransactionManager");
+    }
+    log.info("Unblocking entry {} for retry", entryId);
+    try {
+      if (transactionContext instanceof Transaction) {
+        return persistor.unblock((Transaction) transactionContext, entryId);
+      }
+      Transaction transaction =
+          ((ParameterContextTransactionManager) transactionManager)
+              .transactionFromContext(transactionContext);
+      return persistor.unblock(transaction, entryId);
+    } catch (Exception e) {
+      throw (RuntimeException) Utils.uncheckAndThrow(e);
+    }
+  }
+
+  private <T> T schedule(Class<T> clazz, String uniqueRequestId) {
+    return Utils.createProxy(
+        clazz,
+        (method, args) ->
+            uncheckedly(
+                () -> {
+                  var extracted = transactionManager.extractTransaction(method, args);
+                  TransactionOutboxEntry entry =
+                      newEntry(
+                          extracted.getClazz(),
+                          extracted.getMethodName(),
+                          extracted.getParameters(),
+                          extracted.getArgs(),
+                          uniqueRequestId);
+                  validator.validate(entry);
+                  persistor.save(extracted.getTransaction(), entry);
+                  extracted
+                      .getTransaction()
+                      .addPostCommitHook(
+                          () -> {
+                            listener.scheduled(entry);
+                            submitNow(entry);
+                          });
+                  log.debug(
+                      "Scheduled {} for running after transaction commit", entry.description());
+                  return null;
+                }));
+  }
+
+  private void submitNow(TransactionOutboxEntry entry) {
+    submitter.submit(entry, this::processNow);
+  }
+
+  @Override
+  @SuppressWarnings("WeakerAccess")
+  public void processNow(TransactionOutboxEntry entry) {
+    try {
+      var success =
+          transactionManager.inTransactionReturnsThrows(
+              transaction -> {
+                if (!persistor.lock(transaction, entry)) {
+                  return false;
+                }
+                log.info("Processing {}", entry.description());
+                invoke(entry, transaction);
+                if (entry.getUniqueRequestId() == null) {
+                  persistor.delete(transaction, entry);
+                } else {
+                  log.debug(
+                      "Deferring deletion of {} by {}", entry.description(), retentionThreshold);
+                  entry.setProcessed(true);
+                  entry.setNextAttemptTime(after(retentionThreshold));
+                  persistor.update(transaction, entry);
+                }
+                return true;
+              });
+      if (success) {
+        log.info("Processed {}", entry.description());
+        listener.success(entry);
+      } else {
+        log.debug("Skipped task {} - may be locked or already processed", entry.getId());
+      }
+    } catch (InvocationTargetException e) {
+      updateAttemptCount(entry, e.getCause());
+    } catch (Exception e) {
+      updateAttemptCount(entry, e);
+    }
+  }
+
+  private void invoke(TransactionOutboxEntry entry, Transaction transaction)
+      throws NoSuchMethodException, IllegalAccessException, InvocationTargetException {
+    Object instance = instantiator.getInstance(entry.getInvocation().getClassName());
+    log.debug("Created instance {}", instance);
+    transactionManager.injectTransaction(entry.getInvocation(), transaction).invoke(instance);
+  }
+
+  private TransactionOutboxEntry newEntry(
+      Class<?> clazz, String methodName, Class<?>[] params, Object[] args, String uniqueRequestId) {
+    return TransactionOutboxEntry.builder()
+        .id(UUID.randomUUID().toString())
+        .invocation(
+            new Invocation(
+                instantiator.getName(clazz),
+                methodName,
+                params,
+                args,
+                serializeMdc && (MDC.getMDCAdapter() != null) ? MDC.getCopyOfContextMap() : null))
+        .nextAttemptTime(after(attemptFrequency))
+        .uniqueRequestId(uniqueRequestId)
+        .build();
+  }
+
+  private void pushBack(Transaction transaction, TransactionOutboxEntry entry)
+      throws OptimisticLockException {
+    try {
+      entry.setNextAttemptTime(after(attemptFrequency));
+      validator.validate(entry);
+      persistor.update(transaction, entry);
+    } catch (OptimisticLockException e) {
+      throw e;
+    } catch (Exception e) {
+      Utils.uncheckAndThrow(e);
+    }
+  }
+
+  private Instant after(Duration duration) {
+    return clockProvider.getClock().instant().plus(duration).truncatedTo(MILLIS);
+  }
+
+  private void updateAttemptCount(TransactionOutboxEntry entry, Throwable cause) {
+    try {
+      entry.setAttempts(entry.getAttempts() + 1);
+      var blocked = entry.getAttempts() >= blockAfterAttempts;
+      entry.setBlocked(blocked);
+      entry.setNextAttemptTime(after(attemptFrequency));
+      validator.validate(entry);
+      transactionManager.inTransactionThrows(transaction -> persistor.update(transaction, entry));
+      listener.failure(entry, cause);
+      if (blocked) {
+        log.error(
+            "Blocking failing entry {} after {} attempts: {}",
+            entry.getId(),
+            entry.getAttempts(),
+            entry.description(),
+            cause);
+        listener.blocked(entry, cause);
+      } else {
+        logAtLevel(
+            log,
+            logLevelTemporaryFailure,
+            "Temporarily failed to process entry {} : {}",
+            entry.getId(),
+            entry.description(),
+            cause);
+      }
+    } catch (Exception e) {
+      log.error(
+          "Failed to update attempt count for {}. It may be retried more times than expected.",
+          entry.description(),
+          e);
+    }
+  }
+
+  @ToString
+  static class TransactionOutboxBuilderImpl extends TransactionOutboxBuilder {
+
+    TransactionOutboxBuilderImpl() {
+      super();
+    }
+
+    public TransactionOutboxImpl build() {
+      return new TransactionOutboxImpl(
+          transactionManager,
+          instantiator,
+          submitter,
+          attemptFrequency,
+          blockAfterAttempts,
+          flushBatchSize,
+          clockProvider,
+          listener,
+          persistor,
+          logLevelTemporaryFailure,
+          serializeMdc,
+          retentionThreshold);
+    }
+  }
+
+  private class ParameterizedScheduleBuilderImpl implements ParameterizedScheduleBuilder {
+
+    @Length(max = 250)
+    private String uniqueRequestId;
+
+    @Override
+    public ParameterizedScheduleBuilder uniqueRequestId(String uniqueRequestId) {
+      this.uniqueRequestId = uniqueRequestId;
+      return this;
+    }
+
+    @Override
+    public <T> T schedule(Class<T> clazz) {
+      validator.validate(this);
+      return TransactionOutboxImpl.this.schedule(clazz, uniqueRequestId);
+    }
+  }
+}

--- a/transactionoutbox-core/src/main/java/com/gruelbox/transactionoutbox/Utils.java
+++ b/transactionoutbox-core/src/main/java/com/gruelbox/transactionoutbox/Utils.java
@@ -150,12 +150,48 @@ class Utils {
     }
   }
 
+  static <T> Supplier<T> memoise(Supplier<T> supplier) {
+    return new Memoiser<>(supplier);
+  }
+
   private static boolean hasDefaultConstructor(Class<?> clazz) {
     try {
       clazz.getConstructor();
       return true;
     } catch (NoSuchMethodException e) {
       return false;
+    }
+  }
+
+  /**
+   * Strongly inspired by the {@code MemoizingSupplier} in <a
+   * href="https://github.com/google/guava">Guava</a>.
+   *
+   * @param <T> The type memoised.
+   */
+  private static class Memoiser<T> implements Supplier<T> {
+    private volatile Supplier<T> supplier;
+    private volatile boolean initialized;
+    private T value;
+
+    private Memoiser(Supplier<T> supplier) {
+      this.supplier = supplier;
+    }
+
+    @Override
+    public T get() {
+      if (!this.initialized) {
+        synchronized (this) {
+          if (!this.initialized) {
+            T t = this.supplier.get();
+            this.value = t;
+            this.initialized = true;
+            this.supplier = null;
+            return t;
+          }
+        }
+      }
+      return this.value;
     }
   }
 }

--- a/transactionoutbox-core/src/test/java/com/gruelbox/transactionoutbox/AbstractDefaultPersistorTest.java
+++ b/transactionoutbox-core/src/test/java/com/gruelbox/transactionoutbox/AbstractDefaultPersistorTest.java
@@ -23,7 +23,6 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import lombok.extern.slf4j.Slf4j;
-import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.BeforeEach;
@@ -364,7 +363,6 @@ abstract class AbstractDefaultPersistorTest {
         .build();
   }
 
-  @NotNull
   private Invocation createInvocation() {
     return new Invocation(
         "Foo",

--- a/transactionoutbox-core/src/test/java/com/gruelbox/transactionoutbox/TestDefaultPersistorH2.java
+++ b/transactionoutbox-core/src/test/java/com/gruelbox/transactionoutbox/TestDefaultPersistorH2.java
@@ -1,9 +1,7 @@
 package com.gruelbox.transactionoutbox;
 
-import lombok.extern.slf4j.Slf4j;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
-@Slf4j
 @Testcontainers
 class TestDefaultPersistorH2 extends AbstractDefaultPersistorTest {
 

--- a/transactionoutbox-core/src/test/java/com/gruelbox/transactionoutbox/TestDefaultPersistorMySql5.java
+++ b/transactionoutbox-core/src/test/java/com/gruelbox/transactionoutbox/TestDefaultPersistorMySql5.java
@@ -1,13 +1,11 @@
 package com.gruelbox.transactionoutbox;
 
 import java.time.Duration;
-import lombok.extern.slf4j.Slf4j;
 import org.testcontainers.containers.JdbcDatabaseContainer;
 import org.testcontainers.containers.MySQLContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
-@Slf4j
 @Testcontainers
 class TestDefaultPersistorMySql5 extends AbstractDefaultPersistorTest {
 

--- a/transactionoutbox-core/src/test/java/com/gruelbox/transactionoutbox/TestDefaultPersistorMySql8.java
+++ b/transactionoutbox-core/src/test/java/com/gruelbox/transactionoutbox/TestDefaultPersistorMySql8.java
@@ -1,13 +1,11 @@
 package com.gruelbox.transactionoutbox;
 
 import java.time.Duration;
-import lombok.extern.slf4j.Slf4j;
 import org.testcontainers.containers.JdbcDatabaseContainer;
 import org.testcontainers.containers.MySQLContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
-@Slf4j
 @Testcontainers
 class TestDefaultPersistorMySql8 extends AbstractDefaultPersistorTest {
 

--- a/transactionoutbox-core/src/test/java/com/gruelbox/transactionoutbox/TestDefaultPersistorPostgres10.java
+++ b/transactionoutbox-core/src/test/java/com/gruelbox/transactionoutbox/TestDefaultPersistorPostgres10.java
@@ -1,13 +1,11 @@
 package com.gruelbox.transactionoutbox;
 
 import java.time.Duration;
-import lombok.extern.slf4j.Slf4j;
 import org.testcontainers.containers.JdbcDatabaseContainer;
 import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
-@Slf4j
 @Testcontainers
 class TestDefaultPersistorPostgres10 extends AbstractDefaultPersistorTest {
 

--- a/transactionoutbox-core/src/test/java/com/gruelbox/transactionoutbox/acceptance/TestComplexConfigurationExample.java
+++ b/transactionoutbox-core/src/test/java/com/gruelbox/transactionoutbox/acceptance/TestComplexConfigurationExample.java
@@ -13,7 +13,6 @@ import java.sql.Connection;
 import java.time.Duration;
 import java.util.Currency;
 import java.util.Set;
-import java.util.concurrent.Executor;
 import java.util.concurrent.ForkJoinPool;
 import javax.sql.DataSource;
 import lombok.Value;
@@ -35,7 +34,6 @@ class TestComplexConfigurationExample {
 
     DataSource dataSource = Mockito.mock(DataSource.class);
     ServiceLocator myServiceLocator = Mockito.mock(ServiceLocator.class);
-    Executor executor = ForkJoinPool.commonPool();
     EventPublisher eventPublisher = Mockito.mock(EventPublisher.class);
 
     TransactionManager transactionManager = TransactionManager.fromDataSource(dataSource);

--- a/transactionoutbox-core/src/test/java/com/gruelbox/transactionoutbox/acceptance/TestStubbing.java
+++ b/transactionoutbox-core/src/test/java/com/gruelbox/transactionoutbox/acceptance/TestStubbing.java
@@ -23,12 +23,10 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import lombok.Value;
-import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 /** Checks that stubbing {@link TransactionOutbox} works cleanly. */
-@Slf4j
 class TestStubbing {
 
   @Test

--- a/transactionoutbox-jooq/src/test/java/com/gruelbox/transactionoutbox/acceptance/TestJooqTransactionManagerWithThreadLocalProvider.java
+++ b/transactionoutbox-jooq/src/test/java/com/gruelbox/transactionoutbox/acceptance/TestJooqTransactionManagerWithThreadLocalProvider.java
@@ -9,6 +9,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
+import com.gruelbox.transactionoutbox.DefaultPersistor;
 import com.gruelbox.transactionoutbox.Dialect;
 import com.gruelbox.transactionoutbox.Instantiator;
 import com.gruelbox.transactionoutbox.JooqTransactionListener;
@@ -24,6 +25,8 @@ import com.gruelbox.transactionoutbox.TransactionOutboxEntry;
 import com.gruelbox.transactionoutbox.TransactionOutboxListener;
 import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
+
+import java.sql.SQLException;
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
 import java.util.concurrent.ArrayBlockingQueue;
@@ -418,7 +421,16 @@ class TestJooqTransactionManagerWithThreadLocalProvider {
   }
 
   private void clearOutbox(TransactionManager transactionManager) {
-    TestUtils.runSql(transactionManager, "DELETE FROM TXNO_OUTBOX");
+    DefaultPersistor persistor = Persistor.forDialect(Dialect.H2);
+    persistor.migrate(transactionManager);
+    transactionManager.inTransaction(
+        tx -> {
+          try {
+            persistor.clear(tx);
+          } catch (SQLException e) {
+            throw new RuntimeException(e);
+          }
+        });
   }
 
   private void withRunningFlusher(TransactionOutbox outbox, ThrowingRunnable runnable)


### PR DESCRIPTION
Lots of apps have a controlled startup sequence which might mean the persistor won't work until after `TransactionOutbox` has been built.

Also splits out an interface for `TransactionOutbox` so easy proxying is available in emergencies.