### PR TITLE
Revert hibernate-validator from 7.0.1.Final to 6.2.0.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@
       <dependency>
         <groupId>org.hibernate.validator</groupId>
         <artifactId>hibernate-validator</artifactId>
-        <version>7.0.1.Final</version>
+        <version>6.1.5.Final</version>
       </dependency>
       <dependency>
         <groupId>javax.el</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -75,9 +75,14 @@
         <version>7.0.1.Final</version>
       </dependency>
       <dependency>
+        <groupId>javax.el</groupId>
+        <artifactId>javax.el-api</artifactId>
+        <version>3.0.0</version>
+      </dependency>
+      <dependency>
         <groupId>org.glassfish</groupId>
-        <artifactId>jakarta.el</artifactId>
-        <version>4.0.1</version>
+        <artifactId>javax.el</artifactId>
+        <version>3.0.0</version>
       </dependency>
 
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@
       <dependency>
         <groupId>org.hibernate.validator</groupId>
         <artifactId>hibernate-validator</artifactId>
-        <version>6.1.5.Final</version>
+        <version>6.2.0.Final</version>
       </dependency>
       <dependency>
         <groupId>javax.el</groupId>

--- a/transactionoutbox-core/pom.xml
+++ b/transactionoutbox-core/pom.xml
@@ -39,8 +39,12 @@
       <artifactId>hibernate-validator</artifactId>
     </dependency>
     <dependency>
+      <groupId>javax.el</groupId>
+      <artifactId>javax.el-api</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.glassfish</groupId>
-      <artifactId>jakarta.el</artifactId>
+      <artifactId>javax.el</artifactId>
     </dependency>
 
     <!-- Compile time -->

--- a/transactionoutbox-core/src/main/java/com/gruelbox/transactionoutbox/DefaultMigrationManager.java
+++ b/transactionoutbox-core/src/main/java/com/gruelbox/transactionoutbox/DefaultMigrationManager.java
@@ -1,6 +1,5 @@
 package com.gruelbox.transactionoutbox;
 
-import jakarta.validation.constraints.NotNull;
 import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -8,6 +7,8 @@ import java.sql.Statement;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+
+import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;

--- a/transactionoutbox-core/src/main/java/com/gruelbox/transactionoutbox/DefaultMigrationManager.java
+++ b/transactionoutbox-core/src/main/java/com/gruelbox/transactionoutbox/DefaultMigrationManager.java
@@ -7,8 +7,7 @@ import java.sql.Statement;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-
-import jakarta.validation.constraints.NotNull;
+import javax.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
@@ -17,7 +16,6 @@ import lombok.extern.slf4j.Slf4j;
  * Simple database migration manager. Inspired by Flyway, Liquibase, Morf etc, just trimmed down for
  * minimum dependencies.
  */
-@SuppressWarnings("SqlResolve")
 @Slf4j
 class DefaultMigrationManager {
 

--- a/transactionoutbox-core/src/main/java/com/gruelbox/transactionoutbox/DefaultPersistor.java
+++ b/transactionoutbox-core/src/main/java/com/gruelbox/transactionoutbox/DefaultPersistor.java
@@ -13,8 +13,7 @@ import java.sql.Timestamp;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
-
-import jakarta.validation.constraints.NotNull;
+import javax.validation.constraints.NotNull;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -32,7 +31,6 @@ import lombok.extern.slf4j.Slf4j;
  * the other hand, you want to use a completely non-relational underlying data store or do something
  * equally esoteric, you may prefer to implement {@link Persistor} from the ground up.
  */
-@SuppressWarnings("SqlResolve")
 @Slf4j
 @SuperBuilder
 @AllArgsConstructor(access = AccessLevel.PROTECTED)

--- a/transactionoutbox-core/src/main/java/com/gruelbox/transactionoutbox/DefaultPersistor.java
+++ b/transactionoutbox-core/src/main/java/com/gruelbox/transactionoutbox/DefaultPersistor.java
@@ -1,6 +1,5 @@
 package com.gruelbox.transactionoutbox;
 
-import jakarta.validation.constraints.NotNull;
 import java.io.IOException;
 import java.io.Reader;
 import java.io.StringWriter;
@@ -14,6 +13,8 @@ import java.sql.Timestamp;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
+
+import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/transactionoutbox-core/src/main/java/com/gruelbox/transactionoutbox/DriverConnectionProvider.java
+++ b/transactionoutbox-core/src/main/java/com/gruelbox/transactionoutbox/DriverConnectionProvider.java
@@ -2,9 +2,10 @@ package com.gruelbox.transactionoutbox;
 
 import static com.gruelbox.transactionoutbox.Utils.uncheckedly;
 
-import jakarta.validation.constraints.NotBlank;
 import java.sql.Connection;
 import java.sql.DriverManager;
+
+import jakarta.validation.constraints.NotBlank;
 import lombok.experimental.SuperBuilder;
 import lombok.extern.slf4j.Slf4j;
 
@@ -27,7 +28,8 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 final class DriverConnectionProvider implements ConnectionProvider {
 
-  @NotBlank private final String driverClassName;
+  @NotBlank
+  private final String driverClassName;
 
   @NotBlank private final String url;
 

--- a/transactionoutbox-core/src/main/java/com/gruelbox/transactionoutbox/DriverConnectionProvider.java
+++ b/transactionoutbox-core/src/main/java/com/gruelbox/transactionoutbox/DriverConnectionProvider.java
@@ -4,8 +4,7 @@ import static com.gruelbox.transactionoutbox.Utils.uncheckedly;
 
 import java.sql.Connection;
 import java.sql.DriverManager;
-
-import jakarta.validation.constraints.NotBlank;
+import javax.validation.constraints.NotBlank;
 import lombok.experimental.SuperBuilder;
 import lombok.extern.slf4j.Slf4j;
 
@@ -28,8 +27,7 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 final class DriverConnectionProvider implements ConnectionProvider {
 
-  @NotBlank
-  private final String driverClassName;
+  @NotBlank private final String driverClassName;
 
   @NotBlank private final String url;
 

--- a/transactionoutbox-core/src/main/java/com/gruelbox/transactionoutbox/ExecutorSubmitter.java
+++ b/transactionoutbox-core/src/main/java/com/gruelbox/transactionoutbox/ExecutorSubmitter.java
@@ -4,8 +4,7 @@ import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.Executor;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.function.Consumer;
-
-import jakarta.validation.constraints.NotNull;
+import javax.validation.constraints.NotNull;
 import lombok.Builder;
 import lombok.extern.slf4j.Slf4j;
 import org.slf4j.event.Level;

--- a/transactionoutbox-core/src/main/java/com/gruelbox/transactionoutbox/ExecutorSubmitter.java
+++ b/transactionoutbox-core/src/main/java/com/gruelbox/transactionoutbox/ExecutorSubmitter.java
@@ -1,10 +1,11 @@
 package com.gruelbox.transactionoutbox;
 
-import jakarta.validation.constraints.NotNull;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.Executor;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.function.Consumer;
+
+import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
 import lombok.extern.slf4j.Slf4j;
 import org.slf4j.event.Level;

--- a/transactionoutbox-core/src/main/java/com/gruelbox/transactionoutbox/TransactionOutbox.java
+++ b/transactionoutbox-core/src/main/java/com/gruelbox/transactionoutbox/TransactionOutbox.java
@@ -1,9 +1,10 @@
 package com.gruelbox.transactionoutbox;
 
-import jakarta.validation.ClockProvider;
 import java.time.Clock;
 import java.time.Duration;
 import java.util.concurrent.Executor;
+
+import jakarta.validation.ClockProvider;
 import lombok.ToString;
 import org.slf4j.MDC;
 import org.slf4j.event.Level;

--- a/transactionoutbox-core/src/main/java/com/gruelbox/transactionoutbox/TransactionOutbox.java
+++ b/transactionoutbox-core/src/main/java/com/gruelbox/transactionoutbox/TransactionOutbox.java
@@ -3,8 +3,7 @@ package com.gruelbox.transactionoutbox;
 import java.time.Clock;
 import java.time.Duration;
 import java.util.concurrent.Executor;
-
-import jakarta.validation.ClockProvider;
+import javax.validation.ClockProvider;
 import lombok.ToString;
 import org.slf4j.MDC;
 import org.slf4j.event.Level;
@@ -110,7 +109,7 @@ public interface TransactionOutbox {
    * @return True if the request to unblock the entry was successful. May return false if another
    *     thread unblocked the entry first.
    */
-  @SuppressWarnings({"unused"})
+  @SuppressWarnings({"unchecked", "rawtypes"})
   boolean unblock(String entryId, Object transactionContext);
 
   /**

--- a/transactionoutbox-core/src/main/java/com/gruelbox/transactionoutbox/TransactionOutboxEntry.java
+++ b/transactionoutbox-core/src/main/java/com/gruelbox/transactionoutbox/TransactionOutboxEntry.java
@@ -2,11 +2,12 @@ package com.gruelbox.transactionoutbox;
 
 import static java.util.stream.Collectors.joining;
 
+import java.time.Instant;
+import java.util.Arrays;
+
 import jakarta.validation.constraints.Future;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.PositiveOrZero;
-import java.time.Instant;
-import java.util.Arrays;
 import lombok.AccessLevel;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;

--- a/transactionoutbox-core/src/main/java/com/gruelbox/transactionoutbox/TransactionOutboxEntry.java
+++ b/transactionoutbox-core/src/main/java/com/gruelbox/transactionoutbox/TransactionOutboxEntry.java
@@ -4,10 +4,9 @@ import static java.util.stream.Collectors.joining;
 
 import java.time.Instant;
 import java.util.Arrays;
-
-import jakarta.validation.constraints.Future;
-import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.PositiveOrZero;
+import javax.validation.constraints.Future;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.PositiveOrZero;
 import lombok.AccessLevel;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;

--- a/transactionoutbox-core/src/main/java/com/gruelbox/transactionoutbox/TransactionOutboxImpl.java
+++ b/transactionoutbox-core/src/main/java/com/gruelbox/transactionoutbox/TransactionOutboxImpl.java
@@ -5,10 +5,6 @@ import static com.gruelbox.transactionoutbox.Utils.uncheckedly;
 import static java.time.temporal.ChronoUnit.MILLIS;
 import static java.time.temporal.ChronoUnit.MINUTES;
 
-import jakarta.validation.ClockProvider;
-import jakarta.validation.Valid;
-import jakarta.validation.constraints.Min;
-import jakarta.validation.constraints.NotNull;
 import java.lang.reflect.InvocationTargetException;
 import java.time.Duration;
 import java.time.Instant;
@@ -16,6 +12,11 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicBoolean;
+
+import jakarta.validation.ClockProvider;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
 import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
 import org.hibernate.validator.constraints.Length;
@@ -28,8 +29,10 @@ class TransactionOutboxImpl implements TransactionOutbox {
 
   private static final int DEFAULT_FLUSH_BATCH_SIZE = 4096;
 
-  @NotNull private final TransactionManager transactionManager;
-  @Valid @NotNull private final Persistor persistor;
+  @NotNull
+  private final TransactionManager transactionManager;
+  @Valid
+  @NotNull private final Persistor persistor;
   @Valid @NotNull private final Instantiator instantiator;
   @NotNull private final Submitter submitter;
   @NotNull private final Duration attemptFrequency;

--- a/transactionoutbox-core/src/main/java/com/gruelbox/transactionoutbox/TransactionOutboxImpl.java
+++ b/transactionoutbox-core/src/main/java/com/gruelbox/transactionoutbox/TransactionOutboxImpl.java
@@ -12,11 +12,10 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicBoolean;
-
-import jakarta.validation.ClockProvider;
-import jakarta.validation.Valid;
-import jakarta.validation.constraints.Min;
-import jakarta.validation.constraints.NotNull;
+import javax.validation.ClockProvider;
+import javax.validation.Valid;
+import javax.validation.constraints.Min;
+import javax.validation.constraints.NotNull;
 import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
 import org.hibernate.validator.constraints.Length;
@@ -29,10 +28,8 @@ class TransactionOutboxImpl implements TransactionOutbox {
 
   private static final int DEFAULT_FLUSH_BATCH_SIZE = 4096;
 
-  @NotNull
-  private final TransactionManager transactionManager;
-  @Valid
-  @NotNull private final Persistor persistor;
+  @NotNull private final TransactionManager transactionManager;
+  @Valid @NotNull private final Persistor persistor;
   @Valid @NotNull private final Instantiator instantiator;
   @NotNull private final Submitter submitter;
   @NotNull private final Duration attemptFrequency;

--- a/transactionoutbox-core/src/main/java/com/gruelbox/transactionoutbox/Validator.java
+++ b/transactionoutbox-core/src/main/java/com/gruelbox/transactionoutbox/Validator.java
@@ -1,12 +1,12 @@
 package com.gruelbox.transactionoutbox;
 
-import jakarta.validation.ClockProvider;
-import jakarta.validation.Validation;
-import jakarta.validation.ValidationException;
+import javax.validation.ClockProvider;
+import javax.validation.Validation;
+import javax.validation.ValidationException;
 
 class Validator {
 
-  private final jakarta.validation.Validator validator;
+  private final javax.validation.Validator validator;
 
   Validator(ClockProvider clockProvider) {
     this.validator =

--- a/transactionoutbox-core/src/test/java/com/gruelbox/transactionoutbox/TestValidator.java
+++ b/transactionoutbox-core/src/test/java/com/gruelbox/transactionoutbox/TestValidator.java
@@ -7,8 +7,7 @@ import java.math.BigDecimal;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneId;
-
-import jakarta.validation.ValidationException;
+import javax.validation.ValidationException;
 import org.junit.jupiter.api.Test;
 
 class TestValidator {

--- a/transactionoutbox-core/src/test/java/com/gruelbox/transactionoutbox/TestValidator.java
+++ b/transactionoutbox-core/src/test/java/com/gruelbox/transactionoutbox/TestValidator.java
@@ -3,11 +3,12 @@ package com.gruelbox.transactionoutbox;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import jakarta.validation.ValidationException;
 import java.math.BigDecimal;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneId;
+
+import jakarta.validation.ValidationException;
 import org.junit.jupiter.api.Test;
 
 class TestValidator {

--- a/transactionoutbox-spring/src/test/java/com/gruelbox/transactionoutbox/acceptance/EventuallyConsistentControllerTest.java
+++ b/transactionoutbox-spring/src/test/java/com/gruelbox/transactionoutbox/acceptance/EventuallyConsistentControllerTest.java
@@ -30,7 +30,7 @@ class EventuallyConsistentControllerTest {
   void testCheck() throws Exception {
     ResponseEntity<String> response =
         template.getForEntity(base.toString() + "/createCustomer", String.class);
-    assertThat("Done").isEqualTo(response.getBody());
+    assertThat("Done".equals(response.getBody()));
 
     for (int i = 0; i < 10; i++) {
       ResponseEntity<String> exists =

--- a/transactionoutbox-spring/src/test/java/com/gruelbox/transactionoutbox/acceptance/EventuallyConsistentControllerTest.java
+++ b/transactionoutbox-spring/src/test/java/com/gruelbox/transactionoutbox/acceptance/EventuallyConsistentControllerTest.java
@@ -30,7 +30,7 @@ class EventuallyConsistentControllerTest {
   void testCheck() throws Exception {
     ResponseEntity<String> response =
         template.getForEntity(base.toString() + "/createCustomer", String.class);
-    assertThat("Done".equals(response.getBody()));
+    assertThat("Done").isEqualTo(response.getBody());
 
     for (int i = 0; i < 10; i++) {
       ResponseEntity<String> exists =

--- a/transactionoutbox-spring/src/test/java/com/gruelbox/transactionoutbox/acceptance/TransactionOutboxSpringDemoApplication.java
+++ b/transactionoutbox-spring/src/test/java/com/gruelbox/transactionoutbox/acceptance/TransactionOutboxSpringDemoApplication.java
@@ -4,18 +4,12 @@ import com.gruelbox.transactionoutbox.Dialect;
 import com.gruelbox.transactionoutbox.Persistor;
 import com.gruelbox.transactionoutbox.SpringInstantiator;
 import com.gruelbox.transactionoutbox.SpringTransactionManager;
-import com.gruelbox.transactionoutbox.SpringTransactionOutboxConfiguration;
-import com.gruelbox.transactionoutbox.SpringTransactionOutboxFactory;
 import com.gruelbox.transactionoutbox.TransactionOutbox;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.Lazy;
 
-@Import({
-  SpringTransactionOutboxConfiguration.class,
-})
 @SpringBootApplication
 public class TransactionOutboxSpringDemoApplication {
 

--- a/transactionoutbox-spring/src/test/java/com/gruelbox/transactionoutbox/acceptance/TransactionOutboxSpringDemoApplication.java
+++ b/transactionoutbox-spring/src/test/java/com/gruelbox/transactionoutbox/acceptance/TransactionOutboxSpringDemoApplication.java
@@ -5,6 +5,7 @@ import com.gruelbox.transactionoutbox.Persistor;
 import com.gruelbox.transactionoutbox.SpringInstantiator;
 import com.gruelbox.transactionoutbox.SpringTransactionManager;
 import com.gruelbox.transactionoutbox.SpringTransactionOutboxConfiguration;
+import com.gruelbox.transactionoutbox.SpringTransactionOutboxFactory;
 import com.gruelbox.transactionoutbox.TransactionOutbox;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;


### PR DESCRIPTION
Fixes [#165](https://github.com/gruelbox/transaction-outbox/issues/165)

Reverts previous commits with bumping hibernate-validator from 6.1.5.Final to 7.0.1.Final.

Also bumps hibernate-validator from 6.1.5.Final to 6.2.0.Final.