### PR TITLE
✨ replaced CGLIB with ByteBuddy

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ If you find yourself wondering _why bother with the queues now_? You're quite ri
 - Currently, **MySQL**, **PostgreSQL** or **H2** databases (pull requests to support Oracle, SQL Server or any other traditional RDMBS would be trivial. Beyond that, a SQL database is not strictly necessary for the pattern to work, merely a data store with the concept of a transaction spanning multiple mutation operations).
 - Database access via **JDBC** (In principle, JDBC should not be required - alternatives such as R2DBC are under investigation - but the API is currently tied to it)
 - Native transactions (not JTA or similar).
+- (Optional) Proxying non-interfaces requires [ByteBuddy](https://bytebuddy.net/#/) to be added as a dependency
 
 ### Stable releases
 The latest stable release is available from Maven Central. Stable releases are [sort-of semantically versioned](https://semver.org/). That is, they follow semver in every respect other than that the version numbers are not monotically increasing. The project uses continuous delivery and selects individual stable releases to promote to Central, so Central releases will always be spaced apart numerically. The important thing, though, is that dependencies should be safe to upgrade as long as the major version number has not increased. 

--- a/pom.xml
+++ b/pom.xml
@@ -64,6 +64,7 @@
         <groupId>org.objenesis</groupId>
         <artifactId>objenesis</artifactId>
         <version>3.2</version>
+        <optional>true</optional>
       </dependency>
       <dependency>
         <groupId>com.google.code.gson</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -58,6 +58,7 @@
         <groupId>net.bytebuddy</groupId>
         <artifactId>byte-buddy</artifactId>
         <version>1.12.1</version>
+        <optional>true</optional>
       </dependency>
       <dependency>
         <groupId>org.objenesis</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -55,9 +55,9 @@
         <version>1.7.32</version>
       </dependency>
       <dependency>
-        <groupId>cglib</groupId>
-        <artifactId>cglib</artifactId>
-        <version>3.3.0</version>
+        <groupId>net.bytebuddy</groupId>
+        <artifactId>byte-buddy</artifactId>
+        <version>1.12.1</version>
       </dependency>
       <dependency>
         <groupId>org.objenesis</groupId>

--- a/transactionoutbox-core/pom.xml
+++ b/transactionoutbox-core/pom.xml
@@ -23,8 +23,8 @@
       <artifactId>slf4j-api</artifactId>
     </dependency>
     <dependency>
-      <groupId>cglib</groupId>
-      <artifactId>cglib</artifactId>
+      <groupId>net.bytebuddy</groupId>
+      <artifactId>byte-buddy</artifactId>
     </dependency>
     <dependency>
       <groupId>org.objenesis</groupId>

--- a/transactionoutbox-core/src/main/java/com/gruelbox/transactionoutbox/MissingOptionalDependencyException.java
+++ b/transactionoutbox-core/src/main/java/com/gruelbox/transactionoutbox/MissingOptionalDependencyException.java
@@ -1,0 +1,11 @@
+package com.gruelbox.transactionoutbox;
+
+public class MissingOptionalDependencyException extends RuntimeException {
+
+  public MissingOptionalDependencyException(String groupId, String artifactId) {
+    super(
+        String.format(
+            "You are trying to use an optional feature, which requires an additional dependency (%s:%s). Please add it to your classpath, and try again.",
+            groupId, artifactId));
+  }
+}

--- a/transactionoutbox-core/src/main/java/com/gruelbox/transactionoutbox/ProxyFactory.java
+++ b/transactionoutbox-core/src/main/java/com/gruelbox/transactionoutbox/ProxyFactory.java
@@ -1,0 +1,86 @@
+package com.gruelbox.transactionoutbox;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.util.function.BiFunction;
+import net.bytebuddy.ByteBuddy;
+import net.bytebuddy.TypeCache;
+import net.bytebuddy.TypeCache.Sort;
+import net.bytebuddy.description.modifier.Visibility;
+import net.bytebuddy.dynamic.loading.ClassLoadingStrategy;
+import net.bytebuddy.implementation.InvocationHandlerAdapter;
+import net.bytebuddy.matcher.ElementMatchers;
+import org.objenesis.Objenesis;
+import org.objenesis.ObjenesisStd;
+import org.objenesis.instantiator.ObjectInstantiator;
+
+public class ProxyFactory {
+
+  private static final Objenesis objenesis = new ObjenesisStd();
+  private static final TypeCache<Class<?>> byteBuddyCache = new TypeCache<>(Sort.WEAK);
+
+  private static boolean hasDefaultConstructor(Class<?> clazz) {
+    try {
+      clazz.getConstructor();
+      return true;
+    } catch (NoSuchMethodException e) {
+      return false;
+    }
+  }
+
+  @SuppressWarnings({"unchecked", "cast"})
+  <T> T createProxy(Class<T> clazz, BiFunction<Method, Object[], T> processor) {
+    if (clazz.isInterface()) {
+      // Fastest - we can just proxy an interface directly
+      return (T)
+          Proxy.newProxyInstance(
+              clazz.getClassLoader(),
+              new Class[] {clazz},
+              (proxy, method, args) -> processor.apply(method, args));
+    } else {
+      Class<? extends T> proxy = buildByteBuddyProxyClass(clazz);
+      return constructProxy(clazz, processor, proxy);
+    }
+  }
+
+  private <T> T constructProxy(
+      Class<T> clazz, BiFunction<Method, Object[], T> processor, Class<? extends T> proxy) {
+    final T instance;
+    if (hasDefaultConstructor(clazz)) {
+      instance = Utils.uncheckedly(() -> proxy.getDeclaredConstructor().newInstance());
+    } else {
+      ObjectInstantiator<? extends T> instantiator = objenesis.getInstantiatorOf(proxy);
+      instance = instantiator.newInstance();
+    }
+    Utils.uncheck(
+        () -> {
+          var field = instance.getClass().getDeclaredField("handler");
+          field.set(
+              instance,
+              (InvocationHandler) (proxy1, method, args) -> processor.apply(method, args));
+        });
+    return instance;
+  }
+
+  @SuppressWarnings({"unchecked", "cast"})
+  private <T> Class<? extends T> buildByteBuddyProxyClass(Class<T> clazz) {
+    try {
+      return (Class<? extends T>)
+          byteBuddyCache.findOrInsert(
+              clazz.getClassLoader(),
+              clazz,
+              () ->
+                  new ByteBuddy()
+                      .subclass(clazz)
+                      .defineField("handler", InvocationHandler.class, Visibility.PUBLIC)
+                      .method(ElementMatchers.isDeclaredBy(clazz))
+                      .intercept(InvocationHandlerAdapter.toField("handler"))
+                      .make()
+                      .load(clazz.getClassLoader(), ClassLoadingStrategy.Default.INJECTION)
+                      .getLoaded());
+    } catch (NoClassDefFoundError error) {
+      throw new MissingOptionalDependencyException("net.bytebuddy", "byte-buddy");
+    }
+  }
+}

--- a/transactionoutbox-core/src/main/java/com/gruelbox/transactionoutbox/StubParameterContextTransactionManager.java
+++ b/transactionoutbox-core/src/main/java/com/gruelbox/transactionoutbox/StubParameterContextTransactionManager.java
@@ -51,7 +51,7 @@ public class StubParameterContextTransactionManager<C>
 
   private <T, E extends Exception> T withTransaction(ThrowingTransactionalSupplier<T, E> work)
       throws E {
-    Connection mockConnection = Utils.createLoggingProxy(Connection.class);
+    Connection mockConnection = Utils.createLoggingProxy(new ProxyFactory(), Connection.class);
     C context = contextFactory.get();
     try (SimpleTransaction transaction = new SimpleTransaction(mockConnection, context)) {
       contextMap.put(context, transaction);

--- a/transactionoutbox-core/src/main/java/com/gruelbox/transactionoutbox/StubThreadLocalTransactionManager.java
+++ b/transactionoutbox-core/src/main/java/com/gruelbox/transactionoutbox/StubThreadLocalTransactionManager.java
@@ -29,7 +29,7 @@ public class StubThreadLocalTransactionManager
 
   private <T, E extends Exception> T withTransaction(ThrowingTransactionalSupplier<T, E> work)
       throws E {
-    Connection mockConnection = Utils.createLoggingProxy(Connection.class);
+    Connection mockConnection = Utils.createLoggingProxy(new ProxyFactory(), Connection.class);
     try (SimpleTransaction transaction =
         pushTransaction(new SimpleTransaction(mockConnection, null))) {
       return work.doWork(transaction);

--- a/transactionoutbox-core/src/main/java/com/gruelbox/transactionoutbox/TransactionOutboxImpl.java
+++ b/transactionoutbox-core/src/main/java/com/gruelbox/transactionoutbox/TransactionOutboxImpl.java
@@ -47,6 +47,7 @@ class TransactionOutboxImpl implements TransactionOutbox {
   private final Validator validator;
   @NotNull private final Duration retentionThreshold;
   private final AtomicBoolean initialized = new AtomicBoolean();
+  private final ProxyFactory proxyFactory = new ProxyFactory();
 
   private TransactionOutboxImpl(
       TransactionManager transactionManager,
@@ -217,7 +218,7 @@ class TransactionOutboxImpl implements TransactionOutbox {
     if (!initialized.get()) {
       throw new IllegalStateException("Not initialized");
     }
-    return Utils.createProxy(
+    return proxyFactory.createProxy(
         clazz,
         (method, args) ->
             uncheckedly(

--- a/transactionoutbox-core/src/main/java/com/gruelbox/transactionoutbox/Utils.java
+++ b/transactionoutbox-core/src/main/java/com/gruelbox/transactionoutbox/Utils.java
@@ -1,30 +1,15 @@
 package com.gruelbox.transactionoutbox;
 
-import java.lang.reflect.Method;
-import java.lang.reflect.Proxy;
 import java.util.Arrays;
 import java.util.concurrent.Callable;
-import java.util.function.BiFunction;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
-import net.bytebuddy.ByteBuddy;
-import net.bytebuddy.dynamic.loading.ClassLoadingStrategy;
-import net.bytebuddy.implementation.MethodDelegation;
-import net.bytebuddy.implementation.bind.annotation.AllArguments;
-import net.bytebuddy.implementation.bind.annotation.Origin;
-import net.bytebuddy.implementation.bind.annotation.RuntimeType;
-import net.bytebuddy.matcher.ElementMatchers;
-import org.objenesis.Objenesis;
-import org.objenesis.ObjenesisStd;
-import org.objenesis.instantiator.ObjectInstantiator;
 import org.slf4j.Logger;
 import org.slf4j.event.Level;
 
 @Slf4j
 class Utils {
-
-  private static final Objenesis objenesis = new ObjenesisStd();
 
   @SuppressWarnings({"SameParameterValue", "WeakerAccess", "UnusedReturnValue"})
   static boolean safelyRun(String gerund, ThrowingRunnable runnable) {
@@ -76,49 +61,8 @@ class Utils {
     throw new UncheckedException(e);
   }
 
-  public static class ProxyDelegator<T> {
-
-    private final BiFunction<Method, Object[], T> processor;
-
-    public ProxyDelegator(BiFunction<Method, Object[], T> processor) {
-      this.processor = processor;
-    }
-
-    @RuntimeType
-    public Object intercept(@Origin Method m, @AllArguments Object... args) {
-      return processor.apply(m, args);
-    }
-  }
-
-  @SuppressWarnings({"unchecked", "cast"})
-  static <T> T createProxy(Class<T> clazz, BiFunction<Method, Object[], T> processor) {
-    if (clazz.isInterface()) {
-      // Fastest - we can just proxy an interface directly
-      return (T)
-          Proxy.newProxyInstance(
-              clazz.getClassLoader(),
-              new Class[] {clazz},
-              (proxy, method, args) -> processor.apply(method, args));
-    } else {
-      Class<? extends T> proxy =
-          new ByteBuddy()
-              .subclass(clazz)
-              .method(ElementMatchers.isDeclaredBy(clazz))
-              .intercept(MethodDelegation.to(new ProxyDelegator<>(processor)))
-              .make()
-              .load(clazz.getClassLoader(), ClassLoadingStrategy.Default.INJECTION)
-              .getLoaded();
-      if (hasDefaultConstructor(clazz)) {
-        return uncheckedly(() -> proxy.getDeclaredConstructor().newInstance());
-      } else {
-        ObjectInstantiator<? extends T> instantiator = objenesis.getInstantiatorOf(proxy);
-        return instantiator.newInstance();
-      }
-    }
-  }
-
-  static <T> T createLoggingProxy(Class<T> clazz) {
-    return createProxy(
+  static <T> T createLoggingProxy(ProxyFactory proxyFactory, Class<T> clazz) {
+    return proxyFactory.createProxy(
         clazz,
         (method, args) -> {
           log.info(
@@ -158,15 +102,6 @@ class Utils {
       default:
         logger.warn(message, args);
         break;
-    }
-  }
-
-  private static boolean hasDefaultConstructor(Class<?> clazz) {
-    try {
-      clazz.getConstructor();
-      return true;
-    } catch (NoSuchMethodException e) {
-      return false;
     }
   }
 }

--- a/transactionoutbox-core/src/test/java/com/gruelbox/transactionoutbox/TestProxyGeneration.java
+++ b/transactionoutbox-core/src/test/java/com/gruelbox/transactionoutbox/TestProxyGeneration.java
@@ -22,9 +22,9 @@ class TestProxyGeneration {
     assertTrue(called.get());
   }
 
-  /** CGLIB */
+  /** ByteBuddy */
   @Test
-  void testCGLIB() {
+  void testByteBuddy() {
     AtomicBoolean called = new AtomicBoolean();
     Child proxy =
         Utils.createProxy(

--- a/transactionoutbox-core/src/test/java/com/gruelbox/transactionoutbox/TestProxyGeneration.java
+++ b/transactionoutbox-core/src/test/java/com/gruelbox/transactionoutbox/TestProxyGeneration.java
@@ -3,16 +3,24 @@ package com.gruelbox.transactionoutbox;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.concurrent.atomic.AtomicBoolean;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 class TestProxyGeneration {
+
+  private ProxyFactory proxyFactory;
+
+  @BeforeEach
+  void setUp() {
+    proxyFactory = new ProxyFactory();
+  }
 
   /** Reflection */
   @Test
   void testReflection() {
     AtomicBoolean called = new AtomicBoolean();
     Interface proxy =
-        Utils.createProxy(
+        proxyFactory.createProxy(
             Interface.class,
             (method, args) -> {
               called.set(true);
@@ -27,7 +35,7 @@ class TestProxyGeneration {
   void testByteBuddy() {
     AtomicBoolean called = new AtomicBoolean();
     Child proxy =
-        Utils.createProxy(
+        proxyFactory.createProxy(
             Child.class,
             (method, args) -> {
               called.set(true);
@@ -42,7 +50,7 @@ class TestProxyGeneration {
   void testObjensis() {
     AtomicBoolean called = new AtomicBoolean();
     Parent proxy =
-        Utils.createProxy(
+        proxyFactory.createProxy(
             Parent.class,
             (method, args) -> {
               called.set(true);

--- a/transactionoutbox-core/src/test/java/com/gruelbox/transactionoutbox/acceptance/TestMySql8.java
+++ b/transactionoutbox-core/src/test/java/com/gruelbox/transactionoutbox/acceptance/TestMySql8.java
@@ -14,7 +14,7 @@ class TestMySql8 extends AbstractAcceptanceTest {
   @Container
   @SuppressWarnings("rawtypes")
   private static final JdbcDatabaseContainer container =
-      new MySQLContainer<>("mysql:8").withStartupTimeout(Duration.ofHours(1));
+      new MySQLContainer<>("mysql:8.0.27").withStartupTimeout(Duration.ofMinutes(5));
 
   @Override
   protected ConnectionDetails connectionDetails() {


### PR DESCRIPTION
CGLIB no longer seems to be actively maintained, with the last release being in 2019.

This change replaces CGLIB with [ByteBuddy](https://bytebuddy.net/#/).