### PR TITLE
tasks ordered processing (draft)

### DIFF
--- a/transactionoutbox-core/src/main/java/com/gruelbox/transactionoutbox/DefaultMigrationManager.java
+++ b/transactionoutbox-core/src/main/java/com/gruelbox/transactionoutbox/DefaultMigrationManager.java
@@ -72,7 +72,18 @@ class DefaultMigrationManager {
               8,
               "Update length of invocation column on outbox for MySQL dialects only.",
               "ALTER TABLE TXNO_OUTBOX MODIFY COLUMN invocation MEDIUMTEXT",
-              Map.of(Dialect.POSTGRESQL_9, "", Dialect.H2, "")));
+              Map.of(Dialect.POSTGRESQL_9, "", Dialect.H2, "")),
+          new Migration(
+              9,
+              "Add createTime column to outbox",
+              "ALTER TABLE TXNO_OUTBOX ADD COLUMN createTime TIMESTAMP(6) NULL AFTER invocation",
+              Map.of(
+                  Dialect.POSTGRESQL_9,
+                  "ALTER TABLE TXNO_OUTBOX ADD COLUMN createTime TIMESTAMP(6)")),
+          new Migration(
+              10,
+              "Add groupId column to outbox",
+              "ALTER TABLE TXNO_OUTBOX ADD COLUMN groupId VARCHAR(250)"));
 
   static void migrate(TransactionManager transactionManager, @NotNull Dialect dialect) {
     transactionManager.inTransaction(

--- a/transactionoutbox-core/src/main/java/com/gruelbox/transactionoutbox/Dialect.java
+++ b/transactionoutbox-core/src/main/java/com/gruelbox/transactionoutbox/Dialect.java
@@ -13,12 +13,13 @@ import lombok.Getter;
 @Getter
 @Beta
 public enum Dialect {
-  MY_SQL_5(false, Constants.DEFAULT_DELETE_EXPIRED_STMT),
-  MY_SQL_8(true, Constants.DEFAULT_DELETE_EXPIRED_STMT),
+  MY_SQL_5(false, false, Constants.DEFAULT_DELETE_EXPIRED_STMT),
+  MY_SQL_8(true, true, Constants.DEFAULT_DELETE_EXPIRED_STMT),
   POSTGRESQL_9(
       true,
+      true,
       "DELETE FROM {{table}} WHERE ctid IN (SELECT ctid FROM {{table}} WHERE nextAttemptTime < ? AND processed = true AND blocked = false LIMIT ?)"),
-  H2(false, Constants.DEFAULT_DELETE_EXPIRED_STMT);
+  H2(false, true, Constants.DEFAULT_DELETE_EXPIRED_STMT);
 
   /**
    * @return True if hot row support ({@code SKIP LOCKED}) is available, increasing performance when
@@ -27,6 +28,8 @@ public enum Dialect {
    */
   @SuppressWarnings("JavaDoc")
   private final boolean supportsSkipLock;
+
+  private final boolean supportsWindowFunctions;
 
   /** @return Format string for the SQL required to delete expired retained records. */
   @SuppressWarnings("JavaDoc")

--- a/transactionoutbox-core/src/main/java/com/gruelbox/transactionoutbox/Persistor.java
+++ b/transactionoutbox-core/src/main/java/com/gruelbox/transactionoutbox/Persistor.java
@@ -105,5 +105,8 @@ public interface Persistor {
   List<TransactionOutboxEntry> selectBatch(Transaction tx, int batchSize, Instant now)
       throws Exception;
 
+  List<TransactionOutboxEntry> selectBatchOrdered(Transaction tx, int batchSize, Instant now)
+      throws Exception;
+
   int deleteProcessedAndExpired(Transaction tx, int batchSize, Instant now) throws Exception;
 }

--- a/transactionoutbox-core/src/main/java/com/gruelbox/transactionoutbox/StubPersistor.java
+++ b/transactionoutbox-core/src/main/java/com/gruelbox/transactionoutbox/StubPersistor.java
@@ -46,6 +46,12 @@ public class StubPersistor implements Persistor {
   }
 
   @Override
+  public List<TransactionOutboxEntry> selectBatchOrdered(
+      final Transaction tx, final int batchSize, final Instant now) {
+    return List.of();
+  }
+
+  @Override
   public int deleteProcessedAndExpired(Transaction tx, int batchSize, Instant now) {
     return 0;
   }

--- a/transactionoutbox-core/src/main/java/com/gruelbox/transactionoutbox/TransactionOutbox.java
+++ b/transactionoutbox-core/src/main/java/com/gruelbox/transactionoutbox/TransactionOutbox.java
@@ -88,6 +88,8 @@ public interface TransactionOutbox {
   @SuppressWarnings("UnusedReturnValue")
   boolean flush();
 
+  boolean flushOrdered();
+
   /**
    * Unblocks a blocked entry and resets the attempt count so that it will be retried again.
    * Requires an active transaction and a transaction manager that supports thread local context.
@@ -138,6 +140,7 @@ public interface TransactionOutbox {
     protected Boolean serializeMdc;
     protected Duration retentionThreshold;
     protected Boolean initializeImmediately;
+    protected Boolean submitImmediately;
 
     protected TransactionOutboxBuilder() {}
 
@@ -285,6 +288,16 @@ public interface TransactionOutbox {
     }
 
     /**
+     * @param submitImmediately If true, a task will be submitted immediately after scheduling.
+     * Defaults to true.
+     * @return Builder.
+     */
+    public TransactionOutboxBuilder submitImmediately(boolean submitImmediately) {
+      this.submitImmediately = submitImmediately;
+      return this;
+    }
+
+    /**
      * Creates and initialises the {@link TransactionOutbox}.
      *
      * @return The outbox implementation.
@@ -309,6 +322,10 @@ public interface TransactionOutbox {
      * @return Builder.
      */
     ParameterizedScheduleBuilder uniqueRequestId(String uniqueRequestId);
+
+    default ParameterizedScheduleBuilder groupId(String groupId) {
+      return this;
+    }
 
     /**
      * Equivalent to {@link TransactionOutbox#schedule(Class)}, but applying additional parameters

--- a/transactionoutbox-core/src/main/java/com/gruelbox/transactionoutbox/TransactionOutboxEntry.java
+++ b/transactionoutbox-core/src/main/java/com/gruelbox/transactionoutbox/TransactionOutboxEntry.java
@@ -109,6 +109,10 @@ public class TransactionOutboxEntry {
   @Setter
   private int version;
 
+  @Getter private Instant createTime;
+
+  @Getter private String groupId;
+
   @EqualsAndHashCode.Exclude @ToString.Exclude private volatile boolean initialized;
   @EqualsAndHashCode.Exclude @ToString.Exclude private String description;
 


### PR DESCRIPTION
Plan to add the functionality described in https://github.com/gruelbox/transaction-outbox/issues/198

For tasks that need to be ordered, the main idea is to use a separate `TransactionOutbox` instance with a shorter next attempt and job flush intervals, and optionally with disabled `submitNow` functionality (so tasks are being sent only by a "flush"-job which now has a new `flushOrdered` method).
Currently, ordering is happened by the new `createTime` property in each group.
It's intended to set some value in `groupId()` of `transactionOutbox.with()` builder.

Would like to get some comments about the approach if you don't mind. 
Ofc I'll add docs/tests for it later (decided not to do it until a superficial review).
