### PR TITLE
#305: Calculate the max and not the min between 1 and ForkJoinPool.co…

### DIFF
--- a/transactionoutbox-core/src/main/java/com/gruelbox/transactionoutbox/Submitter.java
+++ b/transactionoutbox-core/src/main/java/com/gruelbox/transactionoutbox/Submitter.java
@@ -35,7 +35,7 @@ public interface Submitter {
     return withExecutor(
         new ThreadPoolExecutor(
             1,
-            Math.min(1, ForkJoinPool.commonPool().getParallelism()),
+            Math.max(1, ForkJoinPool.commonPool().getParallelism()),
             0L,
             TimeUnit.MILLISECONDS,
             new ArrayBlockingQueue<Runnable>(16384)));


### PR DESCRIPTION
Switched Math.min to Math.max to take full capabilities of the available CPUs when using the default thread pool