### PR TITLE
Support and run acceptance tests for PostgreSQL versions 11-16

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![CD](https://github.com/gruelbox/transaction-outbox/workflows/Continous%20Delivery/badge.svg)](https://github.com/gruelbox/transaction-outbox/actions)
 [![CodeFactor](https://www.codefactor.io/repository/github/gruelbox/transaction-outbox/badge)](https://www.codefactor.io/repository/github/gruelbox/transaction-outbox)
 
-A flexible implementation of the [Transaction Outbox Pattern](https://microservices.io/patterns/data/transactional-outbox.html) for Java. `TransactionOutbox` has a clean, extensible API, very few dependencies and plays nicely with a variety of database platforms, transaction management approaches and application frameworks. Every aspect is highly configurable or overridable. It features out-of-the-box support for **Spring DI**, **Spring Txn**, **Guice**, **MySQL 5 & 8**, **PostgreSQL 9-12**, **Oracle 18 & 21** and **H2**.
+A flexible implementation of the [Transaction Outbox Pattern](https://microservices.io/patterns/data/transactional-outbox.html) for Java. `TransactionOutbox` has a clean, extensible API, very few dependencies and plays nicely with a variety of database platforms, transaction management approaches and application frameworks. Every aspect is highly configurable or overridable. It features out-of-the-box support for **Spring DI**, **Spring Txn**, **Guice**, **MySQL 5 & 8**, **PostgreSQL 11-16**, **Oracle 18 & 21** and **H2**.
 
 ## Contents
 

--- a/transactionoutbox-core/src/test/java/com/gruelbox/transactionoutbox/TestDefaultPersistorPostgres16.java
+++ b/transactionoutbox-core/src/test/java/com/gruelbox/transactionoutbox/TestDefaultPersistorPostgres16.java
@@ -7,13 +7,13 @@ import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
 @Testcontainers
-class TestDefaultPersistorPostgres10 extends AbstractDefaultPersistorTest {
+class TestDefaultPersistorPostgres16 extends AbstractDefaultPersistorTest {
 
   @Container
   @SuppressWarnings("rawtypes")
   private static final JdbcDatabaseContainer container =
       (JdbcDatabaseContainer)
-          new PostgreSQLContainer("postgres:10").withStartupTimeout(Duration.ofHours(1));
+          new PostgreSQLContainer("postgres:16").withStartupTimeout(Duration.ofHours(1));
 
   private DefaultPersistor persistor =
       DefaultPersistor.builder().dialect(Dialect.POSTGRESQL_9).build();

--- a/transactionoutbox-core/src/test/java/com/gruelbox/transactionoutbox/acceptance/TestPostgres13.java
+++ b/transactionoutbox-core/src/test/java/com/gruelbox/transactionoutbox/acceptance/TestPostgres13.java
@@ -1,0 +1,30 @@
+package com.gruelbox.transactionoutbox.acceptance;
+
+import com.gruelbox.transactionoutbox.Dialect;
+import java.time.Duration;
+import org.testcontainers.containers.JdbcDatabaseContainer;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@SuppressWarnings("WeakerAccess")
+@Testcontainers
+class TestPostgres13 extends AbstractAcceptanceTest {
+
+  @Container
+  @SuppressWarnings("rawtypes")
+  private static final JdbcDatabaseContainer container =
+      (JdbcDatabaseContainer)
+          new PostgreSQLContainer("postgres:13").withStartupTimeout(Duration.ofHours(1));
+
+  @Override
+  protected ConnectionDetails connectionDetails() {
+    return ConnectionDetails.builder()
+        .dialect(Dialect.POSTGRESQL_9)
+        .driverClassName("org.postgresql.Driver")
+        .url(container.getJdbcUrl())
+        .user(container.getUsername())
+        .password(container.getPassword())
+        .build();
+  }
+}

--- a/transactionoutbox-core/src/test/java/com/gruelbox/transactionoutbox/acceptance/TestPostgres14.java
+++ b/transactionoutbox-core/src/test/java/com/gruelbox/transactionoutbox/acceptance/TestPostgres14.java
@@ -9,13 +9,13 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 
 @SuppressWarnings("WeakerAccess")
 @Testcontainers
-class TestPostgres10 extends AbstractAcceptanceTest {
+class TestPostgres14 extends AbstractAcceptanceTest {
 
   @Container
   @SuppressWarnings("rawtypes")
   private static final JdbcDatabaseContainer container =
       (JdbcDatabaseContainer)
-          new PostgreSQLContainer("postgres:10").withStartupTimeout(Duration.ofHours(1));
+          new PostgreSQLContainer("postgres:14").withStartupTimeout(Duration.ofHours(1));
 
   @Override
   protected ConnectionDetails connectionDetails() {

--- a/transactionoutbox-core/src/test/java/com/gruelbox/transactionoutbox/acceptance/TestPostgres15.java
+++ b/transactionoutbox-core/src/test/java/com/gruelbox/transactionoutbox/acceptance/TestPostgres15.java
@@ -9,13 +9,13 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 
 @SuppressWarnings("WeakerAccess")
 @Testcontainers
-class TestPostgres9 extends AbstractAcceptanceTest {
+class TestPostgres15 extends AbstractAcceptanceTest {
 
   @Container
   @SuppressWarnings("rawtypes")
   private static final JdbcDatabaseContainer container =
       (JdbcDatabaseContainer)
-          new PostgreSQLContainer("postgres:9").withStartupTimeout(Duration.ofHours(1));
+          new PostgreSQLContainer("postgres:15").withStartupTimeout(Duration.ofHours(1));
 
   @Override
   protected ConnectionDetails connectionDetails() {

--- a/transactionoutbox-core/src/test/java/com/gruelbox/transactionoutbox/acceptance/TestPostgres16.java
+++ b/transactionoutbox-core/src/test/java/com/gruelbox/transactionoutbox/acceptance/TestPostgres16.java
@@ -1,0 +1,30 @@
+package com.gruelbox.transactionoutbox.acceptance;
+
+import com.gruelbox.transactionoutbox.Dialect;
+import java.time.Duration;
+import org.testcontainers.containers.JdbcDatabaseContainer;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@SuppressWarnings("WeakerAccess")
+@Testcontainers
+class TestPostgres16 extends AbstractAcceptanceTest {
+
+  @Container
+  @SuppressWarnings("rawtypes")
+  private static final JdbcDatabaseContainer container =
+      (JdbcDatabaseContainer)
+          new PostgreSQLContainer("postgres:16").withStartupTimeout(Duration.ofHours(1));
+
+  @Override
+  protected ConnectionDetails connectionDetails() {
+    return ConnectionDetails.builder()
+        .dialect(Dialect.POSTGRESQL_9)
+        .driverClassName("org.postgresql.Driver")
+        .url(container.getJdbcUrl())
+        .user(container.getUsername())
+        .password(container.getPassword())
+        .build();
+  }
+}


### PR DESCRIPTION
At this time, PostgreSQL versions 11-16 are officially supported according to https://www.postgresql.org/support/versioning/

Remove tests using versions 9 and 10. Add tests using versions 13-16.

(I wanted to contribute something and I thought this could be a start.)