### PR TITLE
Provide access to the database schema

### DIFF
--- a/transactionoutbox-core/src/main/java/com/gruelbox/transactionoutbox/DefaultMigrationManager.java
+++ b/transactionoutbox-core/src/main/java/com/gruelbox/transactionoutbox/DefaultMigrationManager.java
@@ -1,5 +1,7 @@
 package com.gruelbox.transactionoutbox;
 
+import java.io.PrintWriter;
+import java.io.Writer;
 import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -108,6 +110,25 @@ class DefaultMigrationManager {
             throw new RuntimeException("Migrations failed", e);
           }
         });
+  }
+
+  static void writeSchema(Writer writer, Dialect dialect) {
+    PrintWriter printWriter = new PrintWriter(writer);
+    MIGRATIONS.forEach(
+        migration -> {
+          printWriter.print("-- ");
+          printWriter.print(migration.version);
+          printWriter.print(": ");
+          printWriter.println(migration.name);
+          String sql = migration.sqlFor(dialect);
+          if (sql.isEmpty()) {
+            printWriter.println("-- Nothing for " + dialect);
+          } else {
+            printWriter.println(sql);
+          }
+          printWriter.println();
+        });
+    printWriter.flush();
   }
 
   @SneakyThrows

--- a/transactionoutbox-core/src/main/java/com/gruelbox/transactionoutbox/DefaultPersistor.java
+++ b/transactionoutbox-core/src/main/java/com/gruelbox/transactionoutbox/DefaultPersistor.java
@@ -3,6 +3,7 @@ package com.gruelbox.transactionoutbox;
 import java.io.IOException;
 import java.io.Reader;
 import java.io.StringWriter;
+import java.io.Writer;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -64,8 +65,9 @@ public class DefaultPersistor implements Persistor, Validatable {
   /**
    * @param migrate Set to false to disable automatic database migrations. This may be preferred if
    *     the default migration behaviour interferes with your existing toolset, and you prefer to
-   *     manage the migrations explicitly (e.g. using FlyWay or Liquibase), or your do not give the
-   *     application DDL permissions at runtime.
+   *     manage the migrations explicitly (e.g. using FlyWay or Liquibase), or you do not give the
+   *     application DDL permissions at runtime. You may use {@link #writeSchema(Writer)} to access
+   *     the migrations.
    */
   @SuppressWarnings("JavaDoc")
   @Builder.Default
@@ -74,7 +76,7 @@ public class DefaultPersistor implements Persistor, Validatable {
   /**
    * @param serializer The serializer to use for {@link Invocation}s. See {@link
    *     InvocationSerializer} for more information. Defaults to {@link
-   *     InvocationSerializer#createDefaultJsonSerializer()} with no custom serializable classes..
+   *     InvocationSerializer#createDefaultJsonSerializer()} with no custom serializable classes.
    */
   @SuppressWarnings("JavaDoc")
   @Builder.Default
@@ -92,6 +94,16 @@ public class DefaultPersistor implements Persistor, Validatable {
     if (migrate) {
       DefaultMigrationManager.migrate(transactionManager, dialect);
     }
+  }
+
+  /**
+   * Provides access to the database schema so that you may optionally use your existing toolset to
+   * manage migrations.
+   *
+   * @param writer The writer to which the migrations are written.
+   */
+  public void writeSchema(Writer writer) {
+    DefaultMigrationManager.writeSchema(writer, dialect);
   }
 
   @Override


### PR DESCRIPTION
For users that want to manage the migrations automatically, `DefaultPersistor` now has the `writeSchema` method.

Fixes #485

The output from the new `writeSchema` method looks like this for the `H2` dialect:

```
-- 1: Create outbox table
CREATE TABLE TXNO_OUTBOX (
    id VARCHAR(36) PRIMARY KEY,
    invocation TEXT,
    nextAttemptTime TIMESTAMP(6),
    attempts INT,
    blacklisted BOOLEAN,
    version INT
)

-- 2: Add unique request id
ALTER TABLE TXNO_OUTBOX ADD COLUMN uniqueRequestId VARCHAR(100) NULL UNIQUE

-- 3: Add processed flag
ALTER TABLE TXNO_OUTBOX ADD COLUMN processed BOOLEAN

-- 4: Add flush index
CREATE INDEX IX_TXNO_OUTBOX_1 ON TXNO_OUTBOX (processed, blacklisted, nextAttemptTime)

-- 5: Increase size of uniqueRequestId
ALTER TABLE TXNO_OUTBOX ALTER COLUMN uniqueRequestId VARCHAR(250)

-- 6: Rename column blacklisted to blocked
ALTER TABLE TXNO_OUTBOX RENAME COLUMN blacklisted TO blocked

-- 7: Add lastAttemptTime column to outbox
ALTER TABLE TXNO_OUTBOX ADD COLUMN lastAttemptTime TIMESTAMP(6) NULL AFTER invocation

-- 8: Update length of invocation column on outbox for MySQL dialects only.
-- Nothing for H2
```
Users can of course use a `FileWriter` or a `StringWriter` or whatever suit them best.