### PR TITLE
Rewrote queries to support future SQL Server Limit and Skip Locking.

### DIFF
--- a/transactionoutbox-acceptance/src/test/java/com/gruelbox/transactionoutbox/acceptance/persistor/TestDefaultPersistorH2.java
+++ b/transactionoutbox-acceptance/src/test/java/com/gruelbox/transactionoutbox/acceptance/persistor/TestDefaultPersistorH2.java
@@ -31,4 +31,9 @@ class TestDefaultPersistorH2 extends AbstractPersistorTest {
   protected Dialect dialect() {
     return Dialect.H2;
   }
+
+  @Override
+  public void testSkipLocked() throws Exception {
+    // Not supported.
+  }
 }

--- a/transactionoutbox-acceptance/src/test/java/com/gruelbox/transactionoutbox/acceptance/persistor/TestDefaultPersistorMySql5.java
+++ b/transactionoutbox-acceptance/src/test/java/com/gruelbox/transactionoutbox/acceptance/persistor/TestDefaultPersistorMySql5.java
@@ -44,4 +44,9 @@ class TestDefaultPersistorMySql5 extends AbstractPersistorTest {
   protected Dialect dialect() {
     return Dialect.MY_SQL_5;
   }
+
+  @Override
+  public void testSkipLocked() throws Exception {
+    // Not supported.
+  }
 }

--- a/transactionoutbox-core/src/main/java/com/gruelbox/transactionoutbox/Dialect.java
+++ b/transactionoutbox-core/src/main/java/com/gruelbox/transactionoutbox/Dialect.java
@@ -7,20 +7,14 @@ import java.util.stream.Stream;
 
 /** The SQL dialects supported by {@link DefaultPersistor}. */
 public interface Dialect {
-
-  /**
-   * @return True if hot row support ({@code SKIP LOCKED}) is available, increasing performance when
-   *     there are multiple instances of the application potentially competing to process the same
-   *     task.
-   */
-  boolean isSupportsSkipLock();
-
   /**
    * @return Format string for the SQL required to delete expired retained records.
    */
   String getDeleteExpired();
 
-  String getLimitCriteria();
+  String getSelectBatch();
+
+  String getLock();
 
   String getCheckSql();
 
@@ -31,12 +25,29 @@ public interface Dialect {
   Stream<Migration> getMigrations();
 
   Dialect MY_SQL_5 = DefaultDialect.builder("MY_SQL_5").build();
-  Dialect MY_SQL_8 = DefaultDialect.builder("MY_SQL_8").supportsSkipLock(true).build();
+  Dialect MY_SQL_8 =
+      DefaultDialect.builder("MY_SQL_8")
+          .deleteExpired(
+              "DELETE FROM {{table}} WHERE nextAttemptTime < ? AND processed = true AND blocked = false"
+                  + " LIMIT {{batchSize}}")
+          .selectBatch(
+              "SELECT {{allFields}} FROM {{table}} WHERE nextAttemptTime < ? "
+                  + "AND blocked = false AND processed = false LIMIT {{batchSize}} FOR UPDATE SKIP LOCKED")
+          .lock(
+              "SELECT id, invocation FROM {{table}} WHERE id = ? AND version = ? FOR "
+                  + "UPDATE SKIP LOCKED")
+          .build();
   Dialect POSTGRESQL_9 =
       DefaultDialect.builder("POSTGRESQL_9")
-          .supportsSkipLock(true)
           .deleteExpired(
-              "DELETE FROM {{table}} WHERE id IN (SELECT id FROM {{table}} WHERE nextAttemptTime < ? AND processed = true AND blocked = false LIMIT ?)")
+              "DELETE FROM {{table}} WHERE id IN "
+                  + "(SELECT id FROM {{table}} WHERE nextAttemptTime < ? AND processed = true AND blocked = false LIMIT {{batchSize}})")
+          .selectBatch(
+              "SELECT {{allFields}} FROM {{table}} WHERE nextAttemptTime < ? "
+                  + "AND blocked = false AND processed = false LIMIT {{batchSize}} FOR UPDATE SKIP LOCKED")
+          .lock(
+              "SELECT id, invocation FROM {{table}} WHERE id = ? AND version = ? FOR "
+                  + "UPDATE SKIP LOCKED")
           .changeMigration(
               5, "ALTER TABLE TXNO_OUTBOX ALTER COLUMN uniqueRequestId TYPE VARCHAR(250)")
           .changeMigration(6, "ALTER TABLE TXNO_OUTBOX RENAME COLUMN blacklisted TO blocked")
@@ -52,10 +63,16 @@ public interface Dialect {
           .build();
   Dialect ORACLE =
       DefaultDialect.builder("ORACLE")
-          .supportsSkipLock(true)
           .deleteExpired(
-              "DELETE FROM {{table}} WHERE nextAttemptTime < ? AND processed = 1 AND blocked = 0 AND ROWNUM <= ?")
-          .limitCriteria(" AND ROWNUM <= ?")
+              "DELETE FROM {{table}} WHERE nextAttemptTime < ? AND processed = 1 AND blocked = 0 "
+                  + "AND ROWNUM <= {{batchSize}}")
+          .selectBatch(
+              "SELECT {{allFields}} FROM {{table}} WHERE nextAttemptTime < ? "
+                  + "AND blocked = 0 AND processed = 0 AND ROWNUM <= {{batchSize}} FOR UPDATE "
+                  + "SKIP LOCKED")
+          .lock(
+              "SELECT id, invocation FROM {{table}} WHERE id = ? AND version = ? FOR "
+                  + "UPDATE SKIP LOCKED")
           .checkSql("SELECT 1 FROM DUAL")
           .changeMigration(
               1,

--- a/transactionoutbox-testing/src/main/java/com/gruelbox/transactionoutbox/testing/AbstractPersistorTest.java
+++ b/transactionoutbox-testing/src/main/java/com/gruelbox/transactionoutbox/testing/AbstractPersistorTest.java
@@ -276,7 +276,6 @@ public abstract class AbstractPersistorTest {
 
   @Test
   public void testSkipLocked() throws Exception {
-    Assumptions.assumeTrue(dialect().isSupportsSkipLock());
 
     var entry1 = createEntry("FOO1", now.minusSeconds(1), false);
     var entry2 = createEntry("FOO2", now.minusSeconds(1), false);


### PR DESCRIPTION
Looking to support SQL Server in the future and noticed changes were required for Limit and Skip locking. 

Some example SQL Server queries to support this:
Select Batch
`SELECT TOP ({{batchSize}}) {{allFields}} FROM {{table}} WITH (UPDLOCK, ROWLOCK, READPAST) WHERE nextAttemptTime < ? AND blocked = 0 AND processed = 0`
Select Version
`SELECT version FROM TXNO_VERSION WITH (UPDLOCK, ROWLOCK, READPAST)`
Delete Expired
`DELETE TOP ({{batchSize}}) FROM {{table}} WHERE nextAttemptTime < ? AND processed = 1 AND blocked = 0`

Among others.

This would be the first of a series of changes to support SQL Server.