### PR TITLE
Remove javax.inject dependency

### DIFF
--- a/transactionoutbox-spring/pom.xml
+++ b/transactionoutbox-spring/pom.xml
@@ -38,11 +38,6 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>javax.inject</groupId>
-      <artifactId>javax.inject</artifactId>
-      <version>1</version>
-    </dependency>
-    <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-context</artifactId>
       <version>${spring.version}</version>

--- a/transactionoutbox-spring/src/test/java/com/gruelbox/transactionoutbox/spring/example/EventuallyConsistentControllerTest.java
+++ b/transactionoutbox-spring/src/test/java/com/gruelbox/transactionoutbox/spring/example/EventuallyConsistentControllerTest.java
@@ -6,9 +6,9 @@ import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.net.URL;
-import javax.inject.Inject;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.boot.test.web.server.LocalServerPort;
@@ -23,11 +23,11 @@ class EventuallyConsistentControllerTest {
   private URL base;
 
   @SuppressWarnings("unused")
-  @Inject
+  @Autowired
   private TestRestTemplate template;
 
   @SuppressWarnings("unused")
-  @Inject
+  @Autowired
   private ExternalQueueService externalQueueService;
 
   @BeforeEach


### PR DESCRIPTION
* The `javax` namespace has been replaced by `jakarta`.
* `javax.inject` dependency is not declared with Maven test scope despite the fact it is used only on the test side. It leaks in consuming applications.
* `javax.inject` dependency is only used by a single Spring test that can use `@Autowired` instead

Because of all that, here is a PR that simply removes `javax.inject` dependency.