### PR TITLE
Allow overriding of attemptFrequency and blockAfterAttempts at schedule request level

### DIFF
--- a/transactionoutbox-core/src/main/java/com/gruelbox/transactionoutbox/DefaultDialect.java
+++ b/transactionoutbox-core/src/main/java/com/gruelbox/transactionoutbox/DefaultDialect.java
@@ -158,6 +158,18 @@ class DefaultDialect implements Dialect {
               12,
               "Add flush index to support ordering",
               "CREATE INDEX IX_TXNO_OUTBOX_2 ON TXNO_OUTBOX (topic, processed, seq)"));
+      migrations.put(
+              13,
+              new Migration(
+                      13,
+                      "Add attemptFrequency",
+                      "ALTER TABLE TXNO_OUTBOX ADD COLUMN attemptFrequency INT"));
+      migrations.put(
+              14,
+              new Migration(
+                      14,
+                      "Add blockAfterAttempts",
+                      "ALTER TABLE TXNO_OUTBOX ADD COLUMN blockAfterAttempts INT"));
     }
 
     Builder setMigration(Migration migration) {

--- a/transactionoutbox-core/src/main/java/com/gruelbox/transactionoutbox/TransactionOutbox.java
+++ b/transactionoutbox-core/src/main/java/com/gruelbox/transactionoutbox/TransactionOutbox.java
@@ -395,6 +395,20 @@ public interface TransactionOutbox {
     ParameterizedScheduleBuilder delayForAtLeast(Duration duration);
 
     /**
+     * Use an attemptFrequency that is different from the default set on the {@link TransactionOutbox}.
+     * @param attemptFrequency How often tasks should be re-attempted.
+     * @return Builder.
+     */
+    ParameterizedScheduleBuilder attemptFrequency(Duration attemptFrequency);
+
+    /**
+     * Use a blockAfterAttempts that is different from the default set on the {@link TransactionOutbox}.
+     * @param blockAfterAttempts How many attempts a task should be retried before it is permanently blocked.
+     * @return Builder.
+     */
+    ParameterizedScheduleBuilder blockAfterAttempts(Integer blockAfterAttempts);
+
+    /**
      * Equivalent to {@link TransactionOutbox#schedule(Class)}, but applying additional parameters
      * to the request as configured using {@link TransactionOutbox#with()}.
      *

--- a/transactionoutbox-core/src/main/java/com/gruelbox/transactionoutbox/TransactionOutboxEntry.java
+++ b/transactionoutbox-core/src/main/java/com/gruelbox/transactionoutbox/TransactionOutboxEntry.java
@@ -2,6 +2,7 @@ package com.gruelbox.transactionoutbox;
 
 import static java.util.stream.Collectors.joining;
 
+import java.time.Duration;
 import java.time.Instant;
 import java.util.Arrays;
 import lombok.*;
@@ -82,6 +83,26 @@ public class TransactionOutboxEntry implements Validatable {
   @Getter
   @Setter
   private int attempts;
+
+  /**
+   * @param attemptFrequency How often tasks should be re-attempted.
+   * If null, the default configured on TransactionOutbox will apply.
+   * @return How often tasks should be re-attempted.
+   */
+  @SuppressWarnings("JavaDoc")
+  @Getter
+  @Setter
+  private Duration attemptFrequency;
+
+  /**
+   * @param blockAfterAttempts How many attempts a task should be retried before it is permanently blocked.
+   * If null, the default configured on TransactionOutbox will apply.
+   * @return How many attempts a task should be retried before it is permanently blocked.
+   */
+  @SuppressWarnings("JavaDoc")
+  @Getter
+  @Setter
+  private Integer blockAfterAttempts;
 
   /**
    * @param blocked True if the task has exceeded the configured maximum number of attempts.


### PR DESCRIPTION
Stores the values `attemptFrequency` and `blockAfterAttempts` in the database.

This allows us to have different retry configuration per schedule request.
