### PR TITLE
Increase robustness of outbox flushing with respect to outbox entry deserialization issues

### DIFF
--- a/transactionoutbox-core/src/main/java/com/gruelbox/transactionoutbox/DefaultInvocationSerializer.java
+++ b/transactionoutbox-core/src/main/java/com/gruelbox/transactionoutbox/DefaultInvocationSerializer.java
@@ -1,16 +1,6 @@
 package com.gruelbox.transactionoutbox;
 
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
-import com.google.gson.JsonArray;
-import com.google.gson.JsonDeserializationContext;
-import com.google.gson.JsonDeserializer;
-import com.google.gson.JsonElement;
-import com.google.gson.JsonObject;
-import com.google.gson.JsonParseException;
-import com.google.gson.JsonSerializationContext;
-import com.google.gson.JsonSerializer;
-import com.google.gson.TypeAdapter;
+import com.google.gson.*;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonToken;
 import com.google.gson.stream.JsonWriter;
@@ -106,8 +96,12 @@ public final class DefaultInvocationSerializer implements InvocationSerializer {
   }
 
   @Override
-  public Invocation deserializeInvocation(Reader reader) {
-    return gson.fromJson(reader, Invocation.class);
+  public Invocation deserializeInvocation(Reader reader) throws IOException {
+    try {
+      return gson.fromJson(reader, Invocation.class);
+    } catch (JsonIOException | JsonSyntaxException exception) {
+      throw new IOException(exception);
+    }
   }
 
   private static final class InvocationJsonSerializer

--- a/transactionoutbox-core/src/main/java/com/gruelbox/transactionoutbox/DefaultPersistor.java
+++ b/transactionoutbox-core/src/main/java/com/gruelbox/transactionoutbox/DefaultPersistor.java
@@ -380,7 +380,7 @@ public class DefaultPersistor implements Persistor, Validatable {
       try {
         invocation = serializer.deserializeInvocation(invocationStream);
       } catch (IOException e) {
-        invocation = new Invocation(e);
+        invocation = new FailedDeserializingInvocation(e);
       }
       TransactionOutboxEntry entry =
           TransactionOutboxEntry.builder()

--- a/transactionoutbox-core/src/main/java/com/gruelbox/transactionoutbox/DefaultPersistor.java
+++ b/transactionoutbox-core/src/main/java/com/gruelbox/transactionoutbox/DefaultPersistor.java
@@ -356,10 +356,14 @@ public class DefaultPersistor implements Persistor, Validatable {
   }
 
   private void gatherResults(PreparedStatement stmt, Collection<TransactionOutboxEntry> output)
-      throws SQLException, IOException {
+      throws SQLException {
     try (ResultSet rs = stmt.executeQuery()) {
       while (rs.next()) {
-        output.add(map(rs));
+        try {
+          output.add(map(rs));
+        } catch (IOException e) {
+          log.error("Failed to read entry. Ignoring for now.", e);
+        }
       }
       log.debug("Found {} results", output.size());
     }

--- a/transactionoutbox-core/src/main/java/com/gruelbox/transactionoutbox/DeserializationFailedException.java
+++ b/transactionoutbox-core/src/main/java/com/gruelbox/transactionoutbox/DeserializationFailedException.java
@@ -1,8 +1,0 @@
-package com.gruelbox.transactionoutbox;
-
-/** Thrown when de-serialization of an invocation fails. */
-class DeserializationFailedException extends RuntimeException {
-  DeserializationFailedException(String message, Throwable cause) {
-    super(message, cause);
-  }
-}

--- a/transactionoutbox-core/src/main/java/com/gruelbox/transactionoutbox/DeserializationFailedException.java
+++ b/transactionoutbox-core/src/main/java/com/gruelbox/transactionoutbox/DeserializationFailedException.java
@@ -1,0 +1,9 @@
+package com.gruelbox.transactionoutbox;
+
+
+/** Thrown when de-serialization of an invocation fails. */
+class DeserializationFailedException extends RuntimeException {
+  DeserializationFailedException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/transactionoutbox-core/src/main/java/com/gruelbox/transactionoutbox/DeserializationFailedException.java
+++ b/transactionoutbox-core/src/main/java/com/gruelbox/transactionoutbox/DeserializationFailedException.java
@@ -1,6 +1,5 @@
 package com.gruelbox.transactionoutbox;
 
-
 /** Thrown when de-serialization of an invocation fails. */
 class DeserializationFailedException extends RuntimeException {
   DeserializationFailedException(String message, Throwable cause) {

--- a/transactionoutbox-core/src/main/java/com/gruelbox/transactionoutbox/FailedDeserializingInvocation.java
+++ b/transactionoutbox-core/src/main/java/com/gruelbox/transactionoutbox/FailedDeserializingInvocation.java
@@ -1,0 +1,25 @@
+package com.gruelbox.transactionoutbox;
+
+import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+
+/** Represents an invocation those deserialization failed. */
+public class FailedDeserializingInvocation extends Invocation {
+
+  /**
+   * @return Indicates an Exception during De-Serialization, that is not persisted.
+   */
+  private final transient IOException exceptionDuringDeserialization;
+
+  public FailedDeserializingInvocation(IOException exceptionDuringDeserialization) {
+    super("", "", new Class<?>[] {}, new Object[] {});
+    this.exceptionDuringDeserialization = exceptionDuringDeserialization;
+  }
+
+  @Override
+  void invoke(Object instance, TransactionOutboxListener listener)
+      throws NoSuchMethodException, IllegalAccessException, InvocationTargetException {
+    throw new DeserializationFailedException(
+        "Invocation could not be deserialized", exceptionDuringDeserialization);
+  }
+}

--- a/transactionoutbox-core/src/main/java/com/gruelbox/transactionoutbox/FailedDeserializingInvocation.java
+++ b/transactionoutbox-core/src/main/java/com/gruelbox/transactionoutbox/FailedDeserializingInvocation.java
@@ -19,7 +19,6 @@ public class FailedDeserializingInvocation extends Invocation {
   @Override
   void invoke(Object instance, TransactionOutboxListener listener)
       throws NoSuchMethodException, IllegalAccessException, InvocationTargetException {
-    throw new DeserializationFailedException(
-        "Invocation could not be deserialized", exceptionDuringDeserialization);
+    throw new UncheckedException(exceptionDuringDeserialization);
   }
 }

--- a/transactionoutbox-core/src/main/java/com/gruelbox/transactionoutbox/Invocation.java
+++ b/transactionoutbox-core/src/main/java/com/gruelbox/transactionoutbox/Invocation.java
@@ -1,10 +1,12 @@
 package com.gruelbox.transactionoutbox;
 
 import com.google.gson.annotations.SerializedName;
+import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.Callable;
 import lombok.Value;
 import lombok.extern.slf4j.Slf4j;
@@ -58,6 +60,11 @@ public class Invocation {
   Map<String, String> mdc;
 
   /**
+   * @return Indicates an Exception during De-Serialization, that is not persisted.
+   */
+  transient Optional<Exception> exceptionDuringDeserialization;
+
+  /**
    * @param className The class name (as provided/expected by an {@link Instantiator}).
    * @param methodName The method name. Combined with {@link #parameterTypes}, uniquely identifies
    *     the method.
@@ -89,6 +96,19 @@ public class Invocation {
     this.parameterTypes = parameterTypes;
     this.args = args;
     this.mdc = mdc;
+    this.exceptionDuringDeserialization = Optional.empty();
+  }
+
+  /**
+   * @param exception The exception that occured during de-serialization.
+   */
+  public Invocation(IOException exception) {
+    this.className = "";
+    this.methodName = "";
+    this.parameterTypes = new Class<?>[] {};
+    this.args = new Object[] {};
+    this.mdc = null;
+    this.exceptionDuringDeserialization = Optional.of(exception);
   }
 
   void withinMDC(Runnable runnable) {
@@ -129,11 +149,16 @@ public class Invocation {
 
   void invoke(Object instance, TransactionOutboxListener listener)
       throws NoSuchMethodException, IllegalAccessException, InvocationTargetException {
-    Method method = instance.getClass().getDeclaredMethod(methodName, parameterTypes);
-    method.setAccessible(true);
-    if (log.isDebugEnabled()) {
-      log.debug("Invoking method {} with args {}", method, Arrays.toString(args));
+    if (exceptionDuringDeserialization.isEmpty()) {
+      Method method = instance.getClass().getDeclaredMethod(methodName, parameterTypes);
+      method.setAccessible(true);
+      if (log.isDebugEnabled()) {
+        log.debug("Invoking method {} with args {}", method, Arrays.toString(args));
+      }
+      listener.wrapInvocation(() -> method.invoke(instance, args));
+    } else {
+      throw new DeserializationFailedException(
+          "Invocation could not be de-serialized", exceptionDuringDeserialization.get());
     }
-    listener.wrapInvocation(() -> method.invoke(instance, args));
   }
 }

--- a/transactionoutbox-core/src/main/java/com/gruelbox/transactionoutbox/InvocationSerializer.java
+++ b/transactionoutbox-core/src/main/java/com/gruelbox/transactionoutbox/InvocationSerializer.java
@@ -1,5 +1,6 @@
 package com.gruelbox.transactionoutbox;
 
+import java.io.IOException;
 import java.io.Reader;
 import java.io.Writer;
 
@@ -40,5 +41,5 @@ public interface InvocationSerializer {
    * @param reader The reader.
    * @return The deserialized invocation.
    */
-  Invocation deserializeInvocation(Reader reader);
+  Invocation deserializeInvocation(Reader reader) throws IOException;
 }

--- a/transactionoutbox-jackson/src/main/java/com/gruelbox/transactionoutbox/jackson/CustomInvocationDeserializer.java
+++ b/transactionoutbox-jackson/src/main/java/com/gruelbox/transactionoutbox/jackson/CustomInvocationDeserializer.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import com.fasterxml.jackson.databind.jsontype.TypeDeserializer;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.gruelbox.transactionoutbox.Invocation;
 import java.io.IOException;
@@ -29,6 +30,13 @@ class CustomInvocationDeserializer extends StdDeserializer<Invocation> {
 
   CustomInvocationDeserializer() {
     this(Invocation.class);
+  }
+
+  @Override
+  public Invocation deserializeWithType(
+      JsonParser p, DeserializationContext ctxt, TypeDeserializer typeDeserializer)
+      throws IOException {
+    return deserialize(p, ctxt);
   }
 
   @Override

--- a/transactionoutbox-jackson/src/main/java/com/gruelbox/transactionoutbox/jackson/CustomInvocationSerializer.java
+++ b/transactionoutbox-jackson/src/main/java/com/gruelbox/transactionoutbox/jackson/CustomInvocationSerializer.java
@@ -2,6 +2,7 @@ package com.gruelbox.transactionoutbox.jackson;
 
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.jsontype.TypeSerializer;
 import com.fasterxml.jackson.databind.ser.std.StdSerializer;
 import com.gruelbox.transactionoutbox.Invocation;
 import java.io.IOException;
@@ -14,6 +15,13 @@ class CustomInvocationSerializer extends StdSerializer<Invocation> {
 
   protected CustomInvocationSerializer(Class<Invocation> t) {
     super(t);
+  }
+
+  @Override
+  public void serializeWithType(
+      Invocation value, JsonGenerator gen, SerializerProvider serializers, TypeSerializer typeSer)
+      throws IOException {
+    serialize(value, gen, serializers);
   }
 
   @Override

--- a/transactionoutbox-jackson/src/main/java/com/gruelbox/transactionoutbox/jackson/JacksonInvocationSerializer.java
+++ b/transactionoutbox-jackson/src/main/java/com/gruelbox/transactionoutbox/jackson/JacksonInvocationSerializer.java
@@ -43,24 +43,20 @@ public final class JacksonInvocationSerializer implements InvocationSerializer {
   }
 
   @Override
-  public Invocation deserializeInvocation(Reader reader) {
-    try {
-      // read ahead to check if old style
-      BufferedReader br = new BufferedReader(reader);
-      if (checkForOldSerialization(br)) {
-        if (defaultInvocationSerializer == null) {
-          throw new UnsupportedOperationException(
-              "Can't deserialize GSON-format tasks without a "
-                  + DefaultInvocationSerializer.class.getSimpleName()
-                  + ". Supply one when building "
-                  + getClass().getSimpleName());
-        }
-        return defaultInvocationSerializer.deserializeInvocation(br);
+  public Invocation deserializeInvocation(Reader reader) throws IOException {
+    // read ahead to check if old style
+    BufferedReader br = new BufferedReader(reader);
+    if (checkForOldSerialization(br)) {
+      if (defaultInvocationSerializer == null) {
+        throw new UnsupportedOperationException(
+            "Can't deserialize GSON-format tasks without a "
+                + DefaultInvocationSerializer.class.getSimpleName()
+                + ". Supply one when building "
+                + getClass().getSimpleName());
       }
-      return mapper.readValue(br, Invocation.class);
-    } catch (IOException e) {
-      throw new RuntimeException(e);
+      return defaultInvocationSerializer.deserializeInvocation(br);
     }
+    return mapper.readValue(br, Invocation.class);
   }
 
   private boolean checkForOldSerialization(BufferedReader reader) throws IOException {

--- a/transactionoutbox-jackson/src/test/java/com/gruelbox/transactionoutbox/jackson/TestJacksonInvocationSerializer.java
+++ b/transactionoutbox-jackson/src/test/java/com/gruelbox/transactionoutbox/jackson/TestJacksonInvocationSerializer.java
@@ -9,8 +9,10 @@ import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.gruelbox.transactionoutbox.DefaultInvocationSerializer;
 import com.gruelbox.transactionoutbox.Invocation;
+import java.io.IOException;
 import java.io.StringReader;
 import java.io.StringWriter;
+import java.io.UncheckedIOException;
 import java.time.*;
 import java.time.temporal.ChronoUnit;
 import java.util.*;
@@ -50,9 +52,13 @@ class TestJacksonInvocationSerializer {
   }
 
   Invocation serdeser(Invocation invocation) {
-    var writer = new StringWriter();
-    underTest.serializeInvocation(invocation, writer);
-    return underTest.deserializeInvocation(new StringReader(writer.toString()));
+    try {
+      var writer = new StringWriter();
+      underTest.serializeInvocation(invocation, writer);
+      return underTest.deserializeInvocation(new StringReader(writer.toString()));
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
+    }
   }
 
   @Test
@@ -148,7 +154,7 @@ class TestJacksonInvocationSerializer {
   }
 
   @Test
-  void deserializes_old_representation_correctly() {
+  void deserializes_old_representation_correctly() throws IOException {
     StringReader reader =
         new StringReader(
             "{\"c\":\"com.gruelbox.transactionoutbox.jackson.Service\",\"m\":\"parseDate\",\"p\":[\"String\"],\"a\":[{\"t\":\"String\",\"v\":\"2021-05-11\"}],\"x\":{\"REQUEST-ID\":\"someRequestId\"}}");

--- a/transactionoutbox-testing/src/main/java/com/gruelbox/transactionoutbox/testing/AbstractPersistorTest.java
+++ b/transactionoutbox-testing/src/main/java/com/gruelbox/transactionoutbox/testing/AbstractPersistorTest.java
@@ -453,7 +453,7 @@ public abstract class AbstractPersistorTest {
   }
 
   private Invocation createUnparseableInvocation() {
-    return new Invocation(new IOException());
+    return new FailedDeserializingInvocation(new IOException());
   }
 
   private void expectTobeInterrupted() {

--- a/transactionoutbox-testing/src/main/java/com/gruelbox/transactionoutbox/testing/AbstractPersistorTest.java
+++ b/transactionoutbox-testing/src/main/java/com/gruelbox/transactionoutbox/testing/AbstractPersistorTest.java
@@ -6,6 +6,7 @@ import static org.hamcrest.Matchers.*;
 import static org.junit.jupiter.api.Assertions.*;
 
 import com.gruelbox.transactionoutbox.*;
+import java.io.IOException;
 import java.math.BigDecimal;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
@@ -164,6 +165,21 @@ public abstract class AbstractPersistorTest {
     txManager()
         .inTransactionThrows(
             tx -> assertThat(persistor().selectBatch(tx, 3, now.plusMillis(1)), hasSize(2)));
+  }
+
+  @Test
+  public void testUnparseableEntriesExcluded() throws Exception {
+
+    txManager()
+        .inTransactionThrows(
+            tx -> {
+              persistor().save(tx, createEntry("FOO1", now, false));
+              persistor().save(tx, createEntry("FOO2", now, createUnparseableInvocation()));
+              persistor().save(tx, createEntry("FOO3", now, false));
+            });
+    txManager()
+        .inTransactionThrows(
+            tx -> assertThat(persistor().selectBatch(tx, 3, now.plusMillis(1)), hasSize(3)));
   }
 
   static class TransactionOutboxEntryMatcher extends TypeSafeMatcher<TransactionOutboxEntry> {
@@ -417,12 +433,27 @@ public abstract class AbstractPersistorTest {
         .build();
   }
 
+  private TransactionOutboxEntry createEntry(
+      String id, Instant nextAttemptTime, Invocation invocation) {
+    return TransactionOutboxEntry.builder()
+        .id(id)
+        .invocation(invocation)
+        .blocked(false)
+        .lastAttemptTime(null)
+        .nextAttemptTime(nextAttemptTime.truncatedTo(MILLIS))
+        .build();
+  }
+
   private Invocation createInvocation() {
     return new Invocation(
         "Foo",
         "Bar",
         new Class<?>[] {int.class, BigDecimal.class, String.class},
         new Object[] {1, BigDecimal.TEN, null});
+  }
+
+  private Invocation createUnparseableInvocation() {
+    return new Invocation(new IOException());
   }
 
   private void expectTobeInterrupted() {


### PR DESCRIPTION
Background:
- We are utilizing this framework in all our microservices for certain requests to external and internal downstream services.
- In doing so JacksonInvocationSerializer is used to serialize/deserialize invocations (in a most flexible way).

Problem:
- On rare occassions some outbox entries that were serialized cannot be deserialized successfully.
- For instance this happens when the id of multiple attributes are set to null. However, the concrete issue is not relevant in this context. Most importantly the the call of "deserializeInvocation" at JacksonInvocationSerializer (https://github.com/gruelbox/transaction-outbox/blob/master/transactionoutbox-jackson/src/main/java/com/gruelbox/transactionoutbox/jackson/JacksonInvocationSerializer.java#L46) fails with an IOException.

Analysis:
- As a result the IOException is wrapped in a RuntimeException and is populated to
  - https://github.com/gruelbox/transaction-outbox/blob/master/transactionoutbox-core/src/main/java/com/gruelbox/transactionoutbox/TransactionOutboxImpl.java#L129C53-L129C64
  - https://github.com/gruelbox/transaction-outbox/blob/master/transactionoutbox-core/src/main/java/com/gruelbox/transactionoutbox/TransactionOutboxImpl.java#L142
- Ultimately, the processing of outbox entries stops entirely - even in case the problems applies to a single outbox entry only as part of the batch. As a result no outbox entries are processed.
- In addition the same happens when the outbox is flushed again at a later point in time. 
- Finally, all outbox entries of the microservice are no longer processed.
- A similar observation was made in #628.

Solution:
- The approach suggested here is to handle the IOException at a later point in time at the DefaultPersistor.
- During deserialization of all relevant outbox entries the ones on which the problems applied are ignored (instead of failing the whole operation).
- In doing so deserializeable entries are processed and the processing of remaining outbox entries is not  blocked.

Open points:
- [ ] Please review the solution and provide your feedback.
- [ ] With respect to tests I would plan to extend AbstractPersistorTest, but am struggling since the InvocationSerializer is not exposed yet. Any hints would be welcome.

