### PR TITLE
Enforce UTF-8 on mysql

### DIFF
--- a/transactionoutbox-core/src/main/java/com/gruelbox/transactionoutbox/DefaultDialect.java
+++ b/transactionoutbox-core/src/main/java/com/gruelbox/transactionoutbox/DefaultDialect.java
@@ -163,7 +163,7 @@ class DefaultDialect implements Dialect {
           new Migration(
               12,
               "Enforce UTF8 collation",
-              null"));
+              null));
     }
 
     Builder setMigration(Migration migration) {

--- a/transactionoutbox-core/src/main/java/com/gruelbox/transactionoutbox/DefaultDialect.java
+++ b/transactionoutbox-core/src/main/java/com/gruelbox/transactionoutbox/DefaultDialect.java
@@ -158,6 +158,12 @@ class DefaultDialect implements Dialect {
               12,
               "Add flush index to support ordering",
               "CREATE INDEX IX_TXNO_OUTBOX_2 ON TXNO_OUTBOX (topic, processed, seq)"));
+      migrations.put(
+          13,
+          new Migration(
+              12,
+              "Enforce UTF8 collation",
+              null"));
     }
 
     Builder setMigration(Migration migration) {

--- a/transactionoutbox-core/src/main/java/com/gruelbox/transactionoutbox/Dialect.java
+++ b/transactionoutbox-core/src/main/java/com/gruelbox/transactionoutbox/Dialect.java
@@ -32,7 +32,10 @@ public interface Dialect {
 
   Stream<Migration> getMigrations();
 
-  Dialect MY_SQL_5 = DefaultDialect.builder("MY_SQL_5").build();
+  Dialect MY_SQL_5 =
+      DefaultDialect.builder("MY_SQL_5")
+          .changeMigration(13, "ALTER TABLE TXNO_OUTBOX CONVERT TO CHARACTER SET utf8 COLLATE utf8mb4_unicode_ci")
+          .build();
   Dialect MY_SQL_8 =
       DefaultDialect.builder("MY_SQL_8")
           .fetchNextInAllTopics(
@@ -49,6 +52,7 @@ public interface Dialect {
           .lock(
               "SELECT id, invocation FROM {{table}} WHERE id = ? AND version = ? FOR "
                   + "UPDATE SKIP LOCKED")
+          .changeMigration(13, "ALTER TABLE TXNO_OUTBOX CONVERT TO CHARACTER SET utf8 COLLATE utf8mb4_unicode_ci")
           .build();
   Dialect POSTGRESQL_9 =
       DefaultDialect.builder("POSTGRESQL_9")


### PR DESCRIPTION
Avoids issues with non-ASCII characters in messages on databases where UTF-8 isn't supported by default.