### PR TITLE
MySQL: restore blocked column to BOOLEAN so IX_TXNO_OUTBOX_1 is usable

### DIFF
--- a/transactionoutbox-acceptance/src/test/java/com/gruelbox/transactionoutbox/acceptance/persistor/AbstractMySqlPersistorTest.java
+++ b/transactionoutbox-acceptance/src/test/java/com/gruelbox/transactionoutbox/acceptance/persistor/AbstractMySqlPersistorTest.java
@@ -1,0 +1,114 @@
+package com.gruelbox.transactionoutbox.acceptance.persistor;
+
+import static java.time.temporal.ChronoUnit.MILLIS;
+import static java.util.stream.Collectors.toSet;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.gruelbox.transactionoutbox.Invocation;
+import com.gruelbox.transactionoutbox.Persistor;
+import com.gruelbox.transactionoutbox.TransactionManager;
+import com.gruelbox.transactionoutbox.TransactionOutboxEntry;
+import com.gruelbox.transactionoutbox.testing.AbstractPersistorTest;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.time.Instant;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+/**
+ * MySQL-specific persistor acceptance tests.
+ *
+ * <p>The general tests migrate against an empty table, so they do not cover migration 14 converting
+ * existing data. The migration test rebuilds the database at version 13 (where the MySQL {@code
+ * blocked} column is a VARCHAR holding {@code "0"}/{@code "1"}), seeds records through the
+ * persistor exactly as production did, then migrates to the latest version and asserts the column
+ * type and stored values are converted correctly.
+ */
+abstract class AbstractMySqlPersistorTest extends AbstractPersistorTest {
+
+  private static final int VERSION_BEFORE_BLOCKED_COLUMN_FIX = 13;
+
+  @Test
+  void migration14ConvertsExistingBlockedValues() throws Exception {
+    Persistor persistor = persistor();
+    TransactionManager txManager = txManager();
+    MySqlMigrationTestSupport.recreateSchemaAtVersion(
+        dialect(), txManager, VERSION_BEFORE_BLOCKED_COLUMN_FIX);
+
+    Instant nextAttemptTime = Instant.now().minusSeconds(60).truncatedTo(MILLIS);
+    TransactionOutboxEntry selectableEntry = entry("selectable", false, nextAttemptTime);
+    TransactionOutboxEntry blockedEntry = entry("blocked", true, nextAttemptTime);
+    txManager.inTransactionThrows(
+        tx -> {
+          persistor.save(tx, selectableEntry);
+          persistor.save(tx, blockedEntry);
+        });
+
+    // The persistor writes booleans through setBoolean, so a VARCHAR column holds "0"/"1".
+    assertEquals("varchar", blockedColumnType(txManager));
+    assertEquals("0", blockedValue(txManager, selectableEntry.getId()));
+    assertEquals("1", blockedValue(txManager, blockedEntry.getId()));
+
+    // Migration 14 runs against the populated table.
+    persistor.migrate(txManager);
+
+    assertEquals("tinyint", blockedColumnType(txManager));
+    // Boolean semantics survive the conversion: the blocked record is still excluded from the
+    // batch, and unblocking it (which compares blocked = true) then includes it.
+    assertEquals(Set.of(selectableEntry.getId()), selectableIds(persistor, txManager));
+    boolean wasUnblocked =
+        txManager.inTransactionReturnsThrows(tx -> persistor.unblock(tx, blockedEntry.getId()));
+    assertTrue(wasUnblocked);
+    assertEquals(
+        Set.of(selectableEntry.getId(), blockedEntry.getId()), selectableIds(persistor, txManager));
+  }
+
+  private static TransactionOutboxEntry entry(String id, boolean blocked, Instant nextAttemptTime) {
+    return TransactionOutboxEntry.builder()
+        .id(id)
+        .invocation(new Invocation("Foo", "Bar", new Class<?>[0], new Object[0]))
+        .blocked(blocked)
+        .nextAttemptTime(nextAttemptTime)
+        .build();
+  }
+
+  private static Set<String> selectableIds(Persistor persistor, TransactionManager txManager)
+      throws Exception {
+    return txManager.inTransactionReturnsThrows(
+        tx ->
+            persistor.selectBatch(tx, 10, Instant.now()).stream()
+                .map(TransactionOutboxEntry::getId)
+                .collect(toSet()));
+  }
+
+  private static String blockedColumnType(TransactionManager txManager) throws Exception {
+    return txManager.inTransactionReturnsThrows(
+        tx -> {
+          try (PreparedStatement stmt =
+                  tx.connection()
+                      .prepareStatement(
+                          "SELECT DATA_TYPE FROM INFORMATION_SCHEMA.COLUMNS "
+                              + "WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'TXNO_OUTBOX' "
+                              + "AND COLUMN_NAME = 'blocked'");
+              ResultSet rs = stmt.executeQuery()) {
+            assertTrue(rs.next());
+            return rs.getString(1);
+          }
+        });
+  }
+
+  private static String blockedValue(TransactionManager txManager, String id) throws Exception {
+    return txManager.inTransactionReturnsThrows(
+        tx -> {
+          try (PreparedStatement stmt =
+              tx.connection().prepareStatement("SELECT blocked FROM TXNO_OUTBOX WHERE id = ?")) {
+            stmt.setString(1, id);
+            try (ResultSet rs = stmt.executeQuery()) {
+              assertTrue(rs.next());
+              return rs.getString(1);
+            }
+          }
+        });
+  }
+}

--- a/transactionoutbox-acceptance/src/test/java/com/gruelbox/transactionoutbox/acceptance/persistor/MySqlMigrationTestSupport.java
+++ b/transactionoutbox-acceptance/src/test/java/com/gruelbox/transactionoutbox/acceptance/persistor/MySqlMigrationTestSupport.java
@@ -1,0 +1,78 @@
+package com.gruelbox.transactionoutbox.acceptance.persistor;
+
+import com.gruelbox.transactionoutbox.Dialect;
+import com.gruelbox.transactionoutbox.Migration;
+import com.gruelbox.transactionoutbox.TransactionManager;
+import com.gruelbox.transactionoutbox.testing.TestUtils;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.List;
+
+/** Test support for rebuilding a MySQL database at a historical migration version. */
+final class MySqlMigrationTestSupport {
+
+  private MySqlMigrationTestSupport() {}
+
+  static void recreateSchemaAtVersion(
+      Dialect dialect, TransactionManager txManager, int targetVersion) throws Exception {
+    // Start empty so migrations after targetVersion are not already present.
+    dropAllDatabaseObjects(txManager);
+    txManager.inTransactionThrows(
+        tx -> {
+          dialect.createVersionTableIfNotExists(tx.connection());
+          try (PreparedStatement stmt =
+              tx.connection().prepareStatement("INSERT INTO TXNO_VERSION (version) VALUES (0)")) {
+            stmt.executeUpdate();
+          }
+        });
+
+    for (Migration migration :
+        dialect
+            .getMigrations()
+            .filter(candidate -> candidate.getVersion() <= targetVersion)
+            .toList()) {
+      if (migration.getSql() != null && !migration.getSql().isEmpty()) {
+        TestUtils.runSql(txManager, migration.getSql());
+      }
+      TestUtils.runSql(txManager, "UPDATE TXNO_VERSION SET version = " + migration.getVersion());
+    }
+  }
+
+  private static void dropAllDatabaseObjects(TransactionManager txManager) throws Exception {
+    txManager.inTransactionThrows(
+        tx -> {
+          List<String> tables = new ArrayList<>();
+          List<String> views = new ArrayList<>();
+          try (PreparedStatement stmt =
+                  tx.connection()
+                      .prepareStatement(
+                          "SELECT TABLE_NAME, TABLE_TYPE FROM INFORMATION_SCHEMA.TABLES "
+                              + "WHERE TABLE_SCHEMA = DATABASE()");
+              ResultSet rs = stmt.executeQuery()) {
+            while (rs.next()) {
+              ("VIEW".equals(rs.getString(2)) ? views : tables).add(rs.getString(1));
+            }
+          }
+
+          try (Statement stmt = tx.connection().createStatement()) {
+            for (String view : views) {
+              stmt.execute("DROP VIEW " + quotedIdentifier(view));
+            }
+            stmt.execute("SET FOREIGN_KEY_CHECKS = 0");
+            try {
+              for (String table : tables) {
+                stmt.execute("DROP TABLE " + quotedIdentifier(table));
+              }
+            } finally {
+              stmt.execute("SET FOREIGN_KEY_CHECKS = 1");
+            }
+          }
+        });
+  }
+
+  private static String quotedIdentifier(String identifier) {
+    return "`" + identifier.replace("`", "``") + "`";
+  }
+}

--- a/transactionoutbox-acceptance/src/test/java/com/gruelbox/transactionoutbox/acceptance/persistor/TestDefaultPersistorMySql5.java
+++ b/transactionoutbox-acceptance/src/test/java/com/gruelbox/transactionoutbox/acceptance/persistor/TestDefaultPersistorMySql5.java
@@ -3,7 +3,6 @@ package com.gruelbox.transactionoutbox.acceptance.persistor;
 import com.gruelbox.transactionoutbox.DefaultPersistor;
 import com.gruelbox.transactionoutbox.Dialect;
 import com.gruelbox.transactionoutbox.TransactionManager;
-import com.gruelbox.transactionoutbox.testing.AbstractPersistorTest;
 import java.time.Duration;
 import java.util.Map;
 import org.testcontainers.containers.JdbcDatabaseContainer;
@@ -12,7 +11,7 @@ import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
 @Testcontainers
-class TestDefaultPersistorMySql5 extends AbstractPersistorTest {
+class TestDefaultPersistorMySql5 extends AbstractMySqlPersistorTest {
 
   @Container
   @SuppressWarnings({"rawtypes", "resource"})

--- a/transactionoutbox-acceptance/src/test/java/com/gruelbox/transactionoutbox/acceptance/persistor/TestDefaultPersistorMySql8.java
+++ b/transactionoutbox-acceptance/src/test/java/com/gruelbox/transactionoutbox/acceptance/persistor/TestDefaultPersistorMySql8.java
@@ -3,7 +3,6 @@ package com.gruelbox.transactionoutbox.acceptance.persistor;
 import com.gruelbox.transactionoutbox.DefaultPersistor;
 import com.gruelbox.transactionoutbox.Dialect;
 import com.gruelbox.transactionoutbox.TransactionManager;
-import com.gruelbox.transactionoutbox.testing.AbstractPersistorTest;
 import java.time.Duration;
 import java.util.Map;
 import org.testcontainers.containers.JdbcDatabaseContainer;
@@ -12,7 +11,7 @@ import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
 @Testcontainers
-class TestDefaultPersistorMySql8 extends AbstractPersistorTest {
+class TestDefaultPersistorMySql8 extends AbstractMySqlPersistorTest {
 
   @Container
   @SuppressWarnings({"rawtypes", "resource"})

--- a/transactionoutbox-core/src/main/java/com/gruelbox/transactionoutbox/DefaultDialect.java
+++ b/transactionoutbox-core/src/main/java/com/gruelbox/transactionoutbox/DefaultDialect.java
@@ -166,6 +166,12 @@ class DefaultDialect implements Dialect {
               "Add flush index to support ordering",
               "CREATE INDEX IX_TXNO_OUTBOX_2 ON TXNO_OUTBOX (topic, processed, seq)"));
       migrations.put(13, new Migration(13, "Enforce UTF8 collation for outbox messages", null));
+      migrations.put(
+          14,
+          new Migration(
+              14,
+              "Fix data type of the blocked column, erroneously changed to VARCHAR by migration 6",
+              null));
     }
 
     Builder setMigration(Migration migration) {

--- a/transactionoutbox-core/src/main/java/com/gruelbox/transactionoutbox/Dialect.java
+++ b/transactionoutbox-core/src/main/java/com/gruelbox/transactionoutbox/Dialect.java
@@ -39,6 +39,7 @@ public interface Dialect {
           .changeMigration(
               13,
               "ALTER TABLE TXNO_OUTBOX MODIFY COLUMN invocation mediumtext CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci")
+          .changeMigration(14, "ALTER TABLE TXNO_OUTBOX MODIFY COLUMN blocked BOOLEAN")
           .build();
   Dialect MY_SQL_8 =
       DefaultDialect.builder("MY_SQL_8")
@@ -63,6 +64,7 @@ public interface Dialect {
           .changeMigration(
               13,
               "ALTER TABLE TXNO_OUTBOX MODIFY COLUMN invocation mediumtext CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci")
+          .changeMigration(14, "ALTER TABLE TXNO_OUTBOX MODIFY COLUMN blocked BOOLEAN")
           .build();
   Dialect POSTGRESQL_9 =
       DefaultDialect.builder("POSTGRESQL_9")

--- a/transactionoutbox-core/src/test/java/com/gruelbox/transactionoutbox/TestMySqlDialect.java
+++ b/transactionoutbox-core/src/test/java/com/gruelbox/transactionoutbox/TestMySqlDialect.java
@@ -1,0 +1,47 @@
+package com.gruelbox.transactionoutbox;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+class TestMySqlDialect {
+
+  private static final String MIGRATION_14_SQL =
+      "ALTER TABLE TXNO_OUTBOX MODIFY COLUMN blocked BOOLEAN";
+
+  @Test
+  void mySqlDialectsFixBlockedColumnTypeInMigration14() {
+    assertEquals(MIGRATION_14_SQL, migration14(Dialect.MY_SQL_5).getSql());
+    assertEquals(MIGRATION_14_SQL, migration14(Dialect.MY_SQL_8).getSql());
+  }
+
+  @Test
+  void nonMySqlDialectsHaveNoMigration14Sql() {
+    assertThat(migration14(Dialect.POSTGRESQL_9).getSql(), nullValue());
+    assertThat(migration14(Dialect.H2).getSql(), nullValue());
+    assertThat(migration14(Dialect.ORACLE).getSql(), nullValue());
+    assertThat(migration14(Dialect.MS_SQL_SERVER).getSql(), nullValue());
+  }
+
+  @Test
+  void mySqlQueriesCompareBlockedAsBoolean() {
+    for (Dialect dialect : new Dialect[] {Dialect.MY_SQL_5, Dialect.MY_SQL_8}) {
+      assertThat(dialect.getDeleteExpired(), containsString("blocked = false"));
+      assertThat(dialect.getDeleteExpired(), not(containsString("blocked = '0'")));
+      assertThat(dialect.getSelectBatch(), containsString("blocked = false"));
+      assertThat(dialect.getSelectBatch(), not(containsString("blocked = '0'")));
+    }
+  }
+
+  private static Migration migration14(Dialect dialect) {
+    return dialect
+        .getMigrations()
+        .filter(migration -> migration.getVersion() == 14)
+        .findFirst()
+        .orElseThrow(() -> new AssertionError("Migration 14 not found for " + dialect));
+  }
+}

--- a/transactionoutbox-testing/src/main/java/com/gruelbox/transactionoutbox/testing/AbstractAcceptanceTest.java
+++ b/transactionoutbox-testing/src/main/java/com/gruelbox/transactionoutbox/testing/AbstractAcceptanceTest.java
@@ -27,6 +27,7 @@ import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.time.Clock;
 import java.time.Duration;
+import java.time.Instant;
 import java.util.*;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -388,6 +389,103 @@ public abstract class AbstractAcceptanceTest extends BaseTest {
                 .process("6"));
 
     assertThat(ids, containsInAnyOrder("1", "2", "4", "6"));
+  }
+
+  /**
+   * The retention cleanup deletes nothing when no processed records have expired, and must not lock
+   * the retained records it scans past. On MySQL the {@code blocked} column was mistakenly a
+   * VARCHAR (migration 6), so {@code blocked = false} could not be used as an index range condition
+   * on {@code IX_TXNO_OUTBOX_1}. Under REPEATABLE READ the delete then next-key-locked the entire
+   * {@code processed = true} region, and concurrent outbox writers hit lock wait timeouts.
+   * Migration 14 restores the boolean column type and makes the index usable again.
+   */
+  @Test
+  final void retentionCleanupDoesNotLockRetainedRecords() throws Exception {
+    int count = 100;
+    TransactionManager transactionManager = txManager();
+    Persistor persistor = Persistor.forDialect(connectionDetails().dialect());
+    CountDownLatch processedLatch = new CountDownLatch(count);
+    ProcessedEntryListener listener = new ProcessedEntryListener(processedLatch);
+    TransactionOutbox outbox =
+        TransactionOutbox.builder()
+            .transactionManager(transactionManager)
+            .persistor(persistor)
+            .submitter(Submitter.withExecutor(Runnable::run))
+            .listener(listener)
+            .retentionThreshold(Duration.ofDays(2))
+            .build();
+    clearOutbox();
+
+    // A uniqueRequestId makes a successful task be retained (processed = true, nextAttemptTime in
+    // the future) rather than deleted, so the cleanup below has records to scan but none to delete.
+    transactionManager.inTransaction(
+        () ->
+            IntStream.range(0, count)
+                .forEach(
+                    i ->
+                        outbox
+                            .with()
+                            .uniqueRequestId("retained" + i)
+                            .schedule(ClassProcessor.class)
+                            .process("retained" + i)));
+    assertTrue(processedLatch.await(30, SECONDS));
+
+    // Target the record that is LAST in index order, never the range boundary: a correct range scan
+    // may next-key-lock the first record beyond its range end, but only a scan that wrongly
+    // traverses the whole retained region locks this one.
+    TransactionOutboxEntry target =
+        listener.getSuccessfulEntries().stream()
+            .max(
+                Comparator.comparing(TransactionOutboxEntry::getNextAttemptTime)
+                    .thenComparing(TransactionOutboxEntry::getId))
+            .orElseThrow();
+
+    CountDownLatch cleanupScanned = new CountDownLatch(1);
+    CountDownLatch releaseCleanup = new CountDownLatch(1);
+    ExecutorService executor = Executors.newFixedThreadPool(2);
+    try {
+      // Transaction A: run the retention cleanup (which deletes nothing) and hold it open, as a
+      // slow cleanup batch on another instance would.
+      Future<?> cleanup =
+          executor.submit(
+              () -> {
+                transactionManager.inTransactionThrows(
+                    tx -> {
+                      assertEquals(
+                          0, persistor.deleteProcessedAndExpired(tx, count, Instant.now()));
+                      cleanupScanned.countDown();
+                      assertTrue(
+                          releaseCleanup.await(30, SECONDS),
+                          "Cleanup transaction was not released within 30 seconds");
+                    });
+                return null;
+              });
+      try {
+        assertTrue(cleanupScanned.await(10, SECONDS));
+
+        // Transaction B: writing a single retained record must not block behind the idle cleanup.
+        Future<?> write =
+            executor.submit(
+                () -> {
+                  transactionManager.inTransactionThrows(tx -> persistor.delete(tx, target));
+                  return null;
+                });
+        try {
+          write.get(10, SECONDS);
+        } catch (TimeoutException e) {
+          fail(
+              "Writing a retained record blocked behind an idle retention cleanup transaction. The "
+                  + "cleanup is locking records it should never examine (see migration 14).");
+        }
+      } finally {
+        releaseCleanup.countDown();
+        cleanup.get(10, SECONDS);
+      }
+    } finally {
+      releaseCleanup.countDown();
+      executor.shutdownNow();
+      assertTrue(executor.awaitTermination(30, SECONDS));
+    }
   }
 
   /**


### PR DESCRIPTION
**Problem:** migration 6 renamed blacklisted to blocked but also changed the MySQL column type from `BOOLEAN` to `VARCHAR(250)`. Boolean comparisons against the `VARCHAR` need an implicit cast, so the retention cleanup `DELETE` can't use blocked as an index range condition on `IX_TXNO_OUTBOX_1` and scans the whole `processed = true` region. Under `REPEATABLE READ` it `next-key-locks` every retained row it scans (even when it deletes nothin) and concurrent outbox writers hit lock wait timeouts.

**Fix:** migration 14 (MySQL dialects only) converts the column back to `BOOLEAN`. Existing "0"/"1" values convert in place. Queries keep boolean literals.

Tests:
- `TestMySqlDialect` pins migration 14 SQL and boolean comparisons.
- `migration14ConvertsExistingBlockedValues` rebuilds a populated v13 schema by replaying real migrations, then migrates and verifies type and semantics (MySQL 5 + 8).
- `retentionCleanupDoesNotLockRetainedRecords` proves an idle cleanup transaction no longer blocks writes to retained rows. Passes on H2, MySQL 5/8, PostgreSQL 16, Oracle 21, SQL Server 2019.